### PR TITLE
Optimize SVG assets and improve color contrast

### DIFF
--- a/images/audit.svg
+++ b/images/audit.svg
@@ -1,4 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
-  <circle cx="32" cy="32" r="32" fill="#b8a1e3"/>
-  <text x="32" y="37" text-anchor="middle" font-family="Roboto, sans-serif" font-size="24" fill="#fff">A</text>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"><circle cx="32" cy="32" r="32" fill="#b8a1e3"/><text x="32" y="37" text-anchor="middle" font-family="Roboto, sans-serif" font-size="24" fill="#fff">A</text></svg>

--- a/images/contenu.svg
+++ b/images/contenu.svg
@@ -1,4 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
-  <circle cx="32" cy="32" r="32" fill="#f2b5d4"/>
-  <text x="32" y="37" text-anchor="middle" font-family="Roboto, sans-serif" font-size="24" fill="#fff">C</text>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"><circle cx="32" cy="32" r="32" fill="#f2b5d4"/><text x="32" y="37" text-anchor="middle" font-family="Roboto, sans-serif" font-size="24" fill="#fff">C</text></svg>

--- a/images/hero.svg
+++ b/images/hero.svg
@@ -1,11 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="450" height="350">
-  <defs>
-    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#b8a1e3;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#a9e5bb;stop-opacity:1" />
-    </linearGradient>
-  </defs>
-  <rect width="450" height="350" fill="url(#grad)" />
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle"
-        font-family="Roboto, sans-serif" font-size="48" fill="#ffffff">SEO</text>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="450" height="350"><defs><linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#b8a1e3"/><stop offset="100%" stop-color="#a9e5bb"/></linearGradient></defs><rect width="450" height="350" fill="url(#grad)"/><text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Roboto, sans-serif" font-size="48" fill="#fff">SEO</text></svg>

--- a/images/local.svg
+++ b/images/local.svg
@@ -1,4 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
-  <circle cx="32" cy="32" r="32" fill="#c3f0ca"/>
-  <text x="32" y="37" text-anchor="middle" font-family="Roboto, sans-serif" font-size="24" fill="#fff">L</text>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"><circle cx="32" cy="32" r="32" fill="#c3f0ca"/><text x="32" y="37" text-anchor="middle" font-family="Roboto, sans-serif" font-size="24" fill="#fff">L</text></svg>

--- a/images/netlinking.svg
+++ b/images/netlinking.svg
@@ -1,4 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
-  <circle cx="32" cy="32" r="32" fill="#ffd6a5"/>
-  <text x="32" y="37" text-anchor="middle" font-family="Roboto, sans-serif" font-size="24" fill="#fff">N</text>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"><circle cx="32" cy="32" r="32" fill="#ffd6a5"/><text x="32" y="37" text-anchor="middle" font-family="Roboto, sans-serif" font-size="24" fill="#fff">N</text></svg>

--- a/images/tech.svg
+++ b/images/tech.svg
@@ -1,4 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
-  <circle cx="32" cy="32" r="32" fill="#a9e5bb"/>
-  <text x="32" y="37" text-anchor="middle" font-family="Roboto, sans-serif" font-size="24" fill="#fff">T</text>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"><circle cx="32" cy="32" r="32" fill="#a9e5bb"/><text x="32" y="37" text-anchor="middle" font-family="Roboto, sans-serif" font-size="24" fill="#fff">T</text></svg>

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /* Base */
 :root {
   --primary: #b8a1e3;
-  --primary-dark: #967bc3;
+  --primary-dark: #5d3b8e;
   --secondary: #a9e5bb;
   --light: #f8f9fa;
   --text: #333;
@@ -41,17 +41,18 @@ a {
 .btn {
   display: inline-block;
   background: var(--primary);
-  color: #fff;
+  color: var(--text);
   padding: 0.7rem 1.5rem;
   border-radius: var(--radius);
-  transition: background .3s;
+  transition: background .3s, color .3s;
 }
 .btn:hover {
   background: var(--primary-dark);
+  color: #fff;
 }
 .btn-light {
   background: #fff;
-  color: var(--primary);
+  color: var(--primary-dark);
 }
 
 /* Header */
@@ -65,7 +66,7 @@ a {
 .logo {
   font-size: 1.4rem;
   font-weight: 700;
-  color: var(--primary);
+  color: var(--primary-dark);
 }
 .nav {
   display: flex;
@@ -81,7 +82,7 @@ a {
   margin-left: 1.5rem;
 }
 .nav a:hover {
-  color: var(--primary);
+  color: var(--primary-dark);
 }
 .nav-toggle {
   display: none;
@@ -94,7 +95,7 @@ a {
 /* Hero */
 .hero {
   background: linear-gradient(135deg, var(--primary), var(--secondary));
-  color: #fff;
+  color: var(--text);
   padding: 4rem 0;
 }
 .hero-content {
@@ -158,7 +159,7 @@ a {
 }
 .step .number {
   font-size: 2rem;
-  color: var(--primary);
+  color: var(--primary-dark);
   font-weight: 700;
 }
 


### PR DESCRIPTION
## Summary
- Minify SVG illustrations to shrink page weight
- Adjust palette and button styles for compliant color contrast

## Testing
- `node -e "...contrast"`
- `node -e "...matchAll"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4932f133c8329be17108c5eea787a