### PR TITLE
feat: add service icons and update services section

### DIFF
--- a/images/generated/audit.svg
+++ b/images/generated/audit.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+  <circle cx="32" cy="32" r="32" fill="#b8a1e3"/>
+  <g fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round">
+    <circle cx="28" cy="28" r="10"/>
+    <line x1="34" y1="34" x2="44" y2="44"/>
+  </g>
+</svg>

--- a/images/generated/automatisation-reporting.svg
+++ b/images/generated/automatisation-reporting.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+  <circle cx="32" cy="32" r="32" fill="#a1c4fd"/>
+  <g fill="#fff">
+    <rect x="20" y="28" width="6" height="16" rx="1"/>
+    <rect x="30" y="22" width="6" height="22" rx="1"/>
+    <rect x="40" y="16" width="6" height="28" rx="1"/>
+  </g>
+</svg>

--- a/images/generated/contenu.svg
+++ b/images/generated/contenu.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+  <circle cx="32" cy="32" r="32" fill="#f2b5d4"/>
+  <g fill="none" stroke="#fff" stroke-width="3" stroke-linecap="round">
+    <rect x="20" y="16" width="24" height="32" rx="2"/>
+    <line x1="24" y1="24" x2="40" y2="24"/>
+    <line x1="24" y1="32" x2="40" y2="32"/>
+    <line x1="24" y1="40" x2="40" y2="40"/>
+  </g>
+</svg>

--- a/images/generated/local.svg
+++ b/images/generated/local.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+  <circle cx="32" cy="32" r="32" fill="#c3f0ca"/>
+  <path d="M32 18a10 10 0 0 0-10 10c0 7.5 10 18 10 18s10-10.5 10-18a10 10 0 0 0-10-10z" fill="none" stroke="#fff" stroke-width="4"/>
+  <circle cx="32" cy="28" r="4" fill="#fff"/>
+</svg>

--- a/images/generated/methodologie.svg
+++ b/images/generated/methodologie.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+  <circle cx="32" cy="32" r="32" fill="#ffb4a2"/>
+  <polyline points="20,34 28,42 44,26" fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/images/generated/netlinking.svg
+++ b/images/generated/netlinking.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+  <circle cx="32" cy="32" r="32" fill="#ffd6a5"/>
+  <g fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round">
+    <circle cx="24" cy="32" r="8"/>
+    <circle cx="40" cy="32" r="8"/>
+    <line x1="28" y1="32" x2="36" y2="32"/>
+  </g>
+</svg>

--- a/images/generated/optimisation.svg
+++ b/images/generated/optimisation.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64">
+  <circle cx="32" cy="32" r="32" fill="#a9e5bb"/>
+  <g fill="none" stroke="#fff" stroke-width="4" stroke-linecap="round">
+    <circle cx="32" cy="32" r="10"/>
+    <line x1="32" y1="16" x2="32" y2="8"/>
+    <line x1="32" y1="56" x2="32" y2="48"/>
+    <line x1="16" y1="32" x2="8" y2="32"/>
+    <line x1="56" y1="32" x2="48" y2="32"/>
+    <line x1="45" y1="19" x2="51" y2="13"/>
+    <line x1="19" y1="45" x2="13" y2="51"/>
+    <line x1="45" y1="45" x2="51" y2="51"/>
+    <line x1="19" y1="19" x2="13" y2="13"/>
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -64,55 +64,39 @@
       <h2 class="section-title">Mes services de consultant SEO</h2>
       <div class="cards">
         <article class="card">
-          <img src="images/audit.svg" alt="Audit SEO" />
+          <img src="images/generated/audit.svg" alt="Audit SEO" />
           <h3>Audit SEO</h3>
           <p>Analyse technique, sémantique et concurrentielle pour identifier vos points forts et vos opportunités d’amélioration.</p>
         </article>
         <article class="card">
-          <img src="images/tech.svg" alt="Optimisation technique" />
+          <img src="images/generated/optimisation.svg" alt="Optimisation technique" />
           <h3>Optimisation technique</h3>
           <p>Amélioration de la structure, de l’indexation, de la vitesse de chargement et de l’expérience utilisateur.</p>
         </article>
         <article class="card">
-          <img src="images/contenu.svg" alt="Contenu optimisé" />
+          <img src="images/generated/contenu.svg" alt="Contenu optimisé" />
           <h3>Contenu optimisé</h3>
           <p>Création et optimisation de contenus pertinents, pensés pour répondre aux intentions de recherche de vos prospects.</p>
         </article>
         <article class="card">
-          <img src="images/netlinking.svg" alt="Netlinking" />
+          <img src="images/generated/netlinking.svg" alt="Netlinking" />
           <h3>Netlinking</h3>
           <p>Développement d’un profil de liens naturel et qualitatif pour renforcer l’autorité de votre domaine.</p>
         </article>
         <article class="card">
-          <img src="images/local.svg" alt="Référencement local" />
+          <img src="images/generated/local.svg" alt="Référencement local" />
           <h3>Référencement local</h3>
           <p>Optimisation de votre présence sur Google Maps et dans les résultats géolocalisés pour attirer une clientèle de proximité.</p>
-      <h2 class="section-title">Services</h2>
-      <div class="cards">
-        <article class="card">
-          <img src="https://via.placeholder.com/64" alt="Audit SEO" />
-          <h3>Audit SEO</h3>
-          <p>Analyse technique et concurrentielle pour déceler les opportunités de visibilité.</p>
         </article>
         <article class="card">
-          <img src="https://via.placeholder.com/64" alt="Optimisation technique" />
-          <h3>Optimisation technique</h3>
-          <p>Amélioration de la performance, de l'indexation et de l'expérience utilisateur.</p>
+          <img src="images/generated/automatisation-reporting.svg" alt="Automatisation et reporting" />
+          <h3>Automatisation &amp; reporting</h3>
+          <p>Mise en place d’outils et de tableaux de bord pour suivre et automatiser vos actions SEO.</p>
         </article>
         <article class="card">
-          <img src="https://via.placeholder.com/64" alt="Contenu optimisé" />
-          <h3>Contenu optimisé</h3>
-          <p>Rédaction de contenus pertinents alignés sur les intentions de recherche.</p>
-        </article>
-        <article class="card">
-          <img src="https://via.placeholder.com/64" alt="Netlinking" />
-          <h3>Netlinking</h3>
-          <p>Développement d'un profil de liens de qualité pour renforcer l'autorité du domaine.</p>
-        </article>
-        <article class="card">
-          <img src="https://via.placeholder.com/64" alt="Référencement local" />
-          <h3>Référencement local</h3>
-          <p>Optimisation de votre présence dans les résultats de recherche géolocalisés.</p>
+          <img src="images/generated/methodologie.svg" alt="Méthodologie SEO" />
+          <h3>Méthodologie</h3>
+          <p>Processus structuré pour planifier, exécuter et mesurer chaque étape de votre stratégie SEO.</p>
         </article>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add generated SVG icons for audit, optimisation technique, content, netlinking, local SEO, automation & reporting, and methodology
- update services section to use new icons with alt text for accessibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4961e7de883299661fdd9431e4260