### PR TITLE
feat: generate contact form from JSON

### DIFF
--- a/forms/contact_form.html
+++ b/forms/contact_form.html
@@ -1,0 +1,15 @@
+<form id="contact-form" action="/api/contact" method="POST" class="generated-form contact-form">
+  <div class="form-group">
+    <label for="name">Nom</label>
+    <input id="name" type="text" name="name" placeholder="Votre nom" class="form-input" required/>
+  </div>
+  <div class="form-group">
+    <label for="email">Email</label>
+    <input id="email" type="email" name="email" placeholder="Votre email" class="form-input" required/>
+  </div>
+  <div class="form-group">
+    <label for="message">Message</label>
+    <textarea id="message" name="message" placeholder="Votre message" class="form-textarea" required></textarea>
+  </div>
+  <button type="submit" class="btn">Envoyer</button>
+</form>

--- a/forms/contact_form.json
+++ b/forms/contact_form.json
@@ -1,0 +1,34 @@
+{
+  "action": "/api/contact",
+  "method": "POST",
+  "styles": {
+    "form_class": "generated-form contact-form",
+    "group_class": "form-group",
+    "input_class": "form-input",
+    "textarea_class": "form-textarea",
+    "button_class": "btn"
+  },
+  "fields": [
+    {
+      "type": "text",
+      "name": "name",
+      "label": "Nom",
+      "placeholder": "Votre nom",
+      "required": true
+    },
+    {
+      "type": "email",
+      "name": "email",
+      "label": "Email",
+      "placeholder": "Votre email",
+      "required": true
+    },
+    {
+      "type": "textarea",
+      "name": "message",
+      "label": "Message",
+      "placeholder": "Votre message",
+      "required": true
+    }
+  ]
+}

--- a/forms/generate_form.py
+++ b/forms/generate_form.py
@@ -1,0 +1,72 @@
+import json
+from pathlib import Path
+
+def generate_form(config_path: str, output_path: str | None = None) -> str:
+    """Generate HTML form based on JSON configuration.
+
+    Args:
+        config_path: Path to JSON file with form description.
+        output_path: Optional path to write the generated HTML.
+
+    Returns:
+        The generated HTML string.
+    """
+    with open(config_path, encoding="utf-8") as f:
+        config = json.load(f)
+
+    styles = config.get("styles", {})
+    form_class = styles.get("form_class", "")
+    group_class = styles.get("group_class", "")
+    input_class = styles.get("input_class", "")
+    textarea_class = styles.get("textarea_class", input_class)
+    button_class = styles.get("button_class", "")
+
+    html = [
+        f'<form id="contact-form" action="{config.get("action", "#")}" '
+        f'method="{config.get("method", "post")}" class="{form_class}">' 
+    ]
+
+    for field in config.get("fields", []):
+        field_type = field.get("type", "text")
+        name = field.get("name", "")
+        label = field.get("label", "")
+        placeholder = field.get("placeholder", "")
+        required = " required" if field.get("required", False) else ""
+
+        html.append(f'  <div class="{group_class}">')
+        if label:
+            html.append(f'    <label for="{name}">{label}</label>')
+        if field_type == "textarea":
+            html.append(
+                f'    <textarea id="{name}" name="{name}" placeholder="{placeholder}"'
+                f' class="{textarea_class}"{required}></textarea>'
+            )
+        else:
+            html.append(
+                f'    <input id="{name}" type="{field_type}" name="{name}" '
+                f'placeholder="{placeholder}" class="{input_class}"{required}/>'
+            )
+        html.append("  </div>")
+
+    html.append(f'  <button type="submit" class="{button_class}">Envoyer</button>')
+    html.append("</form>")
+
+    result = "\n".join(html)
+    if output_path:
+        Path(output_path).write_text(result, encoding="utf-8")
+    return result
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Generate HTML form from JSON config")
+    parser.add_argument(
+        "--json", default="forms/contact_form.json", help="Path to JSON config"
+    )
+    parser.add_argument("--out", help="Optional output HTML file")
+    args = parser.parse_args()
+
+    generated_html = generate_form(args.json, args.out)
+    if not args.out:
+        print(generated_html)

--- a/index.html
+++ b/index.html
@@ -172,10 +172,20 @@
     <div class="container">
       <h2 class="section-title">Contact</h2>
       <p>Envie d’échanger sur votre projet SEO ?</p>
-      <form class="contact-form">
-        <input type="text" name="name" placeholder="Nom" required />
-        <input type="email" name="email" placeholder="Email" required />
-        <textarea name="message" placeholder="Message" rows="5" required></textarea>
+      <!-- Formulaire généré depuis forms/contact_form.json -->
+      <form id="contact-form" action="/api/contact" method="POST" class="generated-form contact-form">
+        <div class="form-group">
+          <label for="name">Nom</label>
+          <input id="name" type="text" name="name" placeholder="Votre nom" class="form-input" required/>
+        </div>
+        <div class="form-group">
+          <label for="email">Email</label>
+          <input id="email" type="email" name="email" placeholder="Votre email" class="form-input" required/>
+        </div>
+        <div class="form-group">
+          <label for="message">Message</label>
+          <textarea id="message" name="message" placeholder="Votre message" class="form-textarea" required></textarea>
+        </div>
         <button type="submit" class="btn">Envoyer</button>
       </form>
     </div>

--- a/script.js
+++ b/script.js
@@ -7,11 +7,27 @@ navToggle.addEventListener('click', () => {
 });
 
 // Contact form handler
-const contactForm = document.querySelector('.contact-form');
+const contactForm = document.querySelector('#contact-form');
 if (contactForm) {
-  contactForm.addEventListener('submit', (e) => {
+  contactForm.addEventListener('submit', async (e) => {
     e.preventDefault();
-    alert('Message envoyé !');
-    contactForm.reset();
+
+    const formData = new FormData(contactForm);
+    try {
+      const response = await fetch(contactForm.action || '/api/contact', {
+        method: contactForm.method || 'POST',
+        body: formData,
+      });
+
+      if (!response.ok) {
+        throw new Error('Erreur réseau');
+      }
+
+      alert('Message envoyé !');
+      contactForm.reset();
+    } catch (err) {
+      console.error(err);
+      alert("Une erreur est survenue lors de l'envoi du message.");
+    }
   });
 }

--- a/style.css
+++ b/style.css
@@ -214,6 +214,25 @@ a {
   cursor: pointer;
 }
 
+/* Generated form styles */
+.generated-form .form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.generated-form .form-input,
+.generated-form .form-textarea {
+  padding: 0.8rem;
+  border: 1px solid var(--primary);
+  border-radius: var(--radius);
+  font-family: inherit;
+}
+
+.generated-form .form-textarea {
+  min-height: 120px;
+}
+
 /* Why section */
 .why-list {
   list-style: disc;


### PR DESCRIPTION
## Summary
- define contact form structure and styles in JSON
- generate HTML form from JSON configuration
- handle AJAX form submission and style generated form

## Testing
- `python -m pytest`
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b4961d1cb08329a6bb4b2ba6a31379