### PR TITLE
Refactor sections into cards and add FAQ

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
           <li><a href="#services">Services</a></li>
           <li><a href="#data-ia">Approche data & IA</a></li>
           <li><a href="#process">Méthodologie</a></li>
+          <li><a href="#faq">FAQ</a></li>
           <li><a href="#contact" class="btn">Contact</a></li>
         </ul>
         <button class="nav-toggle" aria-label="menu">&#9776;</button>
@@ -49,10 +50,16 @@
     <div class="container">
       <h2 class="section-title">À propos</h2>
       <p>Je m’appelle Marc Williame, expert SEO freelance basé en Belgique. Mon expertise repose sur deux piliers :</p>
-      <ul>
-        <li>l’analyse de données et l’automatisation, pour identifier rapidement les meilleures opportunités SEO,</li>
-        <li>la stratégie de contenu et l’optimisation technique, pour assurer des résultats concrets et mesurables.</li>
-      </ul>
+      <div class="pillars">
+        <article class="pillar">
+          <h3>Analyse de données & automatisation</h3>
+          <p>Pour identifier rapidement les meilleures opportunités SEO.</p>
+        </article>
+        <article class="pillar">
+          <h3>Stratégie de contenu & optimisation technique</h3>
+          <p>Pour assurer des résultats concrets et mesurables.</p>
+        </article>
+      </div>
       <p>Que vous soyez une PME locale ou une entreprise active à l’international, je conçois des stratégies de référencement sur mesure, adaptées à vos objectifs et à vos ressources.</p>
 
     </div>
@@ -87,32 +94,6 @@
           <img src="images/local.svg" alt="Référencement local" />
           <h3>Référencement local</h3>
           <p>Optimisation de votre présence sur Google Maps et dans les résultats géolocalisés pour attirer une clientèle de proximité.</p>
-      <h2 class="section-title">Services</h2>
-      <div class="cards">
-        <article class="card">
-          <img src="https://via.placeholder.com/64" alt="Audit SEO" />
-          <h3>Audit SEO</h3>
-          <p>Analyse technique et concurrentielle pour déceler les opportunités de visibilité.</p>
-        </article>
-        <article class="card">
-          <img src="https://via.placeholder.com/64" alt="Optimisation technique" />
-          <h3>Optimisation technique</h3>
-          <p>Amélioration de la performance, de l'indexation et de l'expérience utilisateur.</p>
-        </article>
-        <article class="card">
-          <img src="https://via.placeholder.com/64" alt="Contenu optimisé" />
-          <h3>Contenu optimisé</h3>
-          <p>Rédaction de contenus pertinents alignés sur les intentions de recherche.</p>
-        </article>
-        <article class="card">
-          <img src="https://via.placeholder.com/64" alt="Netlinking" />
-          <h3>Netlinking</h3>
-          <p>Développement d'un profil de liens de qualité pour renforcer l'autorité du domaine.</p>
-        </article>
-        <article class="card">
-          <img src="https://via.placeholder.com/64" alt="Référencement local" />
-          <h3>Référencement local</h3>
-          <p>Optimisation de votre présence dans les résultats de recherche géolocalisés.</p>
         </article>
       </div>
     </div>
@@ -123,11 +104,20 @@
     <div class="container">
       <h2 class="section-title">Approche data & IA</h2>
       <p>Je capitalise sur l'analyse de données et l'intelligence artificielle pour prendre des décisions rapides et pertinentes :</p>
-      <ul>
-        <li>Tableaux de bord et suivi des KPI pour comprendre les performances.</li>
-        <li>Scripts d'automatisation pour accélérer les tâches répétitives.</li>
-        <li>Veille continue sur les tendances SEO et l'évolution des algorithmes.</li>
-      </ul>
+      <div class="data-items">
+        <article class="data-item">
+          <h3>Tableaux de bord</h3>
+          <p>Suivi des KPI pour comprendre les performances.</p>
+        </article>
+        <article class="data-item">
+          <h3>Automatisation</h3>
+          <p>Scripts pour accélérer les tâches répétitives.</p>
+        </article>
+        <article class="data-item">
+          <h3>Veille SEO</h3>
+          <p>Tendances SEO et évolution des algorithmes en continu.</p>
+        </article>
+      </div>
     </div>
   </section>
 
@@ -159,12 +149,24 @@
   <section id="why" class="section why">
     <div class="container">
       <h2 class="section-title">Pourquoi travailler avec moi ?</h2>
-      <ul class="why-list">
-        <li><strong>Expertise SEO :</strong> plusieurs années d’expérience dans l’accompagnement de sites web et e-commerces.</li>
-        <li><strong>Approche personnalisée :</strong> chaque stratégie SEO est adaptée à vos besoins et à votre secteur.</li>
-        <li><strong>Vision long terme :</strong> un référencement durable, pensé pour la croissance continue de votre activité.</li>
-        <li><strong>Transparence totale :</strong> suivi clair, reporting régulier et décisions basées sur les faits.</li>
-      </ul>
+      <div class="reasons">
+        <article class="reason">
+          <h3>Expertise SEO</h3>
+          <p>Plusieurs années d’expérience dans l’accompagnement de sites web et e-commerces.</p>
+        </article>
+        <article class="reason">
+          <h3>Approche personnalisée</h3>
+          <p>Chaque stratégie SEO est adaptée à vos besoins et à votre secteur.</p>
+        </article>
+        <article class="reason">
+          <h3>Vision long terme</h3>
+          <p>Un référencement durable, pensé pour la croissance continue de votre activité.</p>
+        </article>
+        <article class="reason">
+          <h3>Transparence totale</h3>
+          <p>Suivi clair, reporting régulier et décisions basées sur les faits.</p>
+        </article>
+      </div>
     </div>
   </section>
   <!-- Contact -->
@@ -178,6 +180,25 @@
         <textarea name="message" placeholder="Message" rows="5" required></textarea>
         <button type="submit" class="btn">Envoyer</button>
       </form>
+    </div>
+  </section>
+
+  <!-- FAQ -->
+  <section id="faq" class="section faq">
+    <div class="container">
+      <h2 class="section-title">FAQ</h2>
+      <details>
+        <summary>Quels outils SEO utilisez-vous&nbsp;?</summary>
+        <p>J'utilise des outils comme Screaming Frog, Google Search Console et des scripts personnalisés pour analyser vos données.</p>
+      </details>
+      <details>
+        <summary>Combien de temps pour voir des résultats&nbsp;?</summary>
+        <p>Les premiers effets apparaissent généralement entre 3 et 6 mois selon votre secteur et la concurrence.</p>
+      </details>
+      <details>
+        <summary>Proposez-vous un accompagnement long terme&nbsp;?</summary>
+        <p>Oui, je peux assurer un suivi mensuel afin d'ajuster la stratégie selon les performances obtenues.</p>
+      </details>
     </div>
   </section>
 

--- a/style.css
+++ b/style.css
@@ -214,10 +214,60 @@ a {
   cursor: pointer;
 }
 
+/* About pillars */
+.about .pillars {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  margin-top: 2rem;
+}
+.pillar {
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: var(--radius);
+  box-shadow: 0 4px 10px rgba(0,0,0,.05);
+}
+
+/* Data & IA items */
+.data-ia .data-items {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  margin-top: 2rem;
+}
+.data-item {
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: var(--radius);
+  box-shadow: 0 4px 10px rgba(0,0,0,.05);
+}
+
 /* Why section */
-.why-list {
-  list-style: disc;
-  padding-left: 1.2rem;
-  max-width: 800px;
+.why .reasons {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  max-width: 1000px;
   margin: 0 auto;
+}
+.reason {
+  background: #fff;
+  padding: 1.5rem;
+  border-radius: var(--radius);
+  box-shadow: 0 4px 10px rgba(0,0,0,.05);
+  text-align: center;
+}
+
+/* FAQ */
+.faq details {
+  max-width: 800px;
+  margin: 0 auto 1rem;
+  background: #fff;
+  padding: 1rem 1.5rem;
+  border-radius: var(--radius);
+  box-shadow: 0 4px 10px rgba(0,0,0,.05);
+}
+.faq summary {
+  font-weight: 500;
+  cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- replace bullet lists with semantic cards and details blocks
- remove duplicate service section and add FAQ with details
- style new sections and update navigation links

## Testing
- `npm test` *(fails: Could not read package.json)*
- `tidy -q -e index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4961aae1883299d2039f6127e9825