### PR TITLE
Fix missing closing brace in style.css

### DIFF
--- a/style.css
+++ b/style.css
@@ -240,6 +240,7 @@ a {
   padding: 1.5rem;
   border-radius: var(--radius);
   box-shadow: 0 4px 10px rgba(0,0,0,.05);
+}
 /* Generated form styles */
 .generated-form .form-group {
   display: flex;


### PR DESCRIPTION
## Summary
- close `.data-item` rule with missing `}` to restore subsequent styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b49b860cc883299e221c817cfe0ef2