### PR TITLE
Refactor footer into three-column layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -259,13 +259,26 @@
   <!-- Footer -->
   <footer class="footer">
     <div class="container">
-      <p>&copy; 2025 Marc Williame. Tous droits réservés.</p>
-      <ul class="local-links">
-        <li><a href="/seo-bruxelles">Consultant SEO Bruxelles</a></li>
-        <li><a href="/seo-liege">Consultant SEO Liège</a></li>
-        <li><a href="/seo-namur">Consultant SEO Namur</a></li>
-      </ul>
-      <p><a href="/mentions-legales">Mentions légales</a> - <a href="/politique-confidentialite">Politique de confidentialité</a></p>
+      <div class="footer-col">
+        <div class="footer-logo">Marc Williame</div>
+        <ul>
+          <li><a href="#about">À propos</a></li>
+          <li><a href="#services">Services</a></li>
+          <li><a href="#process">Méthodologie</a></li>
+          <li><a href="#why">Pourquoi moi&nbsp;?</a></li>
+          <li><a href="#tools">Outils</a></li>
+          <li><a href="#faq">FAQ</a></li>
+          <li><a href="#contact">Contact</a></li>
+        </ul>
+      </div>
+      <div class="footer-col">
+        <p>Marc Williame<br>Bruxelles, Belgique</p>
+        <p><a href="mailto:contact@example.com">contact@example.com</a></p>
+      </div>
+      <div class="footer-col">
+        <p>&copy; 2025 Marc Williame. Tous droits réservés.</p>
+        <p><a href="/mentions-legales">Mentions légales</a><br><a href="/politique-confidentialite">Politique de confidentialité</a></p>
+      </div>
     </div>
   </footer>
 </body>

--- a/style.css
+++ b/style.css
@@ -203,9 +203,24 @@ section:nth-of-type(even) {
   padding: 1.5rem 0;
   font-size: .9rem;
 }
+.footer .container {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 2rem;
+}
+.footer-col {
+  text-align: left;
+}
+.footer-logo {
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
 
 /* Responsive */
 @media (max-width: 768px) {
+  .footer .container {
+    grid-template-columns: 1fr;
+  }
   .nav ul {
     position: absolute;
     top: 60px;


### PR DESCRIPTION
## Summary
- Structure footer into three columns for site navigation, contact details and legal links, including a signature.
- Style footer container as a responsive CSS grid that stacks vertically on small screens.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b49f89e664832996bc4f8920499c92