### PR TITLE
Add accessible accordion for FAQ

### DIFF
--- a/index.html
+++ b/index.html
@@ -233,26 +233,38 @@
   <section id="faq" class="section faq">
     <div class="container">
       <h2 class="section-title">FAQ – SEO, Data &amp; Automatisation</h2>
-      <details>
-        <summary>Quelle est la différence entre un consultant SEO et une agence&nbsp;?</summary>
-        <p>Un consultant SEO indépendant apporte un accompagnement personnalisé, une grande flexibilité et une relation directe, là où une agence applique souvent des méthodes standardisées.</p>
-      </details>
-      <details>
-        <summary>Qu’est-ce qu’un expert SEO axé data&nbsp;?</summary>
-        <p>C’est un consultant SEO qui s’appuie sur les données (trafic, positions, logs, conversions) pour guider ses recommandations et prioriser les actions.</p>
-      </details>
-      <details>
-        <summary>Pourquoi intégrer l’IA et l’automatisation dans le SEO&nbsp;?</summary>
-        <p>Parce qu’elles permettent de gagner du temps sur les tâches répétitives et de se concentrer sur la stratégie. L’IA aide aussi à analyser de grands volumes de données pour mieux comprendre les opportunités.</p>
-      </details>
-      <details>
-        <summary>Combien de temps pour obtenir des résultats SEO&nbsp;?</summary>
-        <p>Selon la concurrence et vos objectifs, les premiers effets apparaissent généralement après 3 à 6 mois. Le SEO reste une stratégie à long terme.</p>
-      </details>
-      <details>
-        <summary>Pouvez-vous mettre en place des dashboards SEO personnalisés&nbsp;?</summary>
-        <p>Oui. Je propose des dashboards (Looker Studio, Notion, Google Sheets) qui centralisent vos KPI et rendent vos données facilement actionnables.</p>
-      </details>
+      <div class="accordion">
+        <div class="accordion-item">
+          <button class="accordion-title" aria-expanded="false" aria-controls="faq1">Quelle est la différence entre un consultant SEO et une agence&nbsp;?</button>
+          <div id="faq1" class="accordion-content" aria-hidden="true">
+            <p>Un consultant SEO indépendant apporte un accompagnement personnalisé, une grande flexibilité et une relation directe, là où une agence applique souvent des méthodes standardisées.</p>
+          </div>
+        </div>
+        <div class="accordion-item">
+          <button class="accordion-title" aria-expanded="false" aria-controls="faq2">Qu’est-ce qu’un expert SEO axé data&nbsp;?</button>
+          <div id="faq2" class="accordion-content" aria-hidden="true">
+            <p>C’est un consultant SEO qui s’appuie sur les données (trafic, positions, logs, conversions) pour guider ses recommandations et prioriser les actions.</p>
+          </div>
+        </div>
+        <div class="accordion-item">
+          <button class="accordion-title" aria-expanded="false" aria-controls="faq3">Pourquoi intégrer l’IA et l’automatisation dans le SEO&nbsp;?</button>
+          <div id="faq3" class="accordion-content" aria-hidden="true">
+            <p>Parce qu’elles permettent de gagner du temps sur les tâches répétitives et de se concentrer sur la stratégie. L’IA aide aussi à analyser de grands volumes de données pour mieux comprendre les opportunités.</p>
+          </div>
+        </div>
+        <div class="accordion-item">
+          <button class="accordion-title" aria-expanded="false" aria-controls="faq4">Combien de temps pour obtenir des résultats SEO&nbsp;?</button>
+          <div id="faq4" class="accordion-content" aria-hidden="true">
+            <p>Selon la concurrence et vos objectifs, les premiers effets apparaissent généralement après 3 à 6 mois. Le SEO reste une stratégie à long terme.</p>
+          </div>
+        </div>
+        <div class="accordion-item">
+          <button class="accordion-title" aria-expanded="false" aria-controls="faq5">Pouvez-vous mettre en place des dashboards SEO personnalisés&nbsp;?</button>
+          <div id="faq5" class="accordion-content" aria-hidden="true">
+            <p>Oui. Je propose des dashboards (Looker Studio, Notion, Google Sheets) qui centralisent vos KPI et rendent vos données facilement actionnables.</p>
+          </div>
+        </div>
+      </div>
     </div>
   </section>
 

--- a/script.js
+++ b/script.js
@@ -31,3 +31,28 @@ if (contactForm) {
     }
   });
 }
+
+// FAQ accordion
+const accordionItems = document.querySelectorAll('.accordion-item');
+accordionItems.forEach(item => {
+  const title = item.querySelector('.accordion-title');
+  const content = item.querySelector('.accordion-content');
+
+  title.addEventListener('click', () => {
+    const isExpanded = title.getAttribute('aria-expanded') === 'true';
+
+    accordionItems.forEach(i => {
+      const t = i.querySelector('.accordion-title');
+      const c = i.querySelector('.accordion-content');
+      t.setAttribute('aria-expanded', 'false');
+      c.setAttribute('aria-hidden', 'true');
+      i.classList.remove('active');
+    });
+
+    if (!isExpanded) {
+      title.setAttribute('aria-expanded', 'true');
+      content.setAttribute('aria-hidden', 'false');
+      item.classList.add('active');
+    }
+  });
+});

--- a/style.css
+++ b/style.css
@@ -310,15 +310,46 @@ section:nth-of-type(even) {
 }
 
 /* FAQ */
-.faq details {
+.faq .accordion-item {
   max-width: 800px;
   margin: 0 auto 1rem;
   background: #fff;
-  padding: 1rem 1.5rem;
+  border: 1px solid var(--primary);
   border-radius: var(--radius);
-  box-shadow: 0 4px 10px rgba(0,0,0,.05);
+  overflow: hidden;
+  transition: border-color .3s;
 }
-.faq summary {
+
+.accordion-title {
+  width: 100%;
+  background: none;
+  border: none;
+  text-align: left;
+  padding: 1rem 1.5rem;
   font-weight: 500;
   cursor: pointer;
+  position: relative;
+}
+
+.accordion-title::after {
+  content: '+';
+  position: absolute;
+  right: 1.5rem;
+  transition: transform .3s;
+}
+
+.accordion-title[aria-expanded="true"]::after {
+  content: '-';
+}
+
+.accordion-content {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height .3s ease;
+  padding: 0 1.5rem;
+}
+
+.accordion-item.active .accordion-content {
+  max-height: 500px;
+  padding-bottom: 1rem;
 }


### PR DESCRIPTION
## Summary
- replace FAQ `<details>` elements with `.accordion-item` structure and buttons
- add JavaScript to open a single accordion item at a time
- style new accordion with borders, plus/minus icons, and transitions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b49f87a0c4832992bbd8b0afbad2eb