### PR TITLE
Improve contact form layout and styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,20 +212,21 @@
       <p>📩 Envoyer un message</p>
       <!-- Formulaire généré depuis forms/contact_form.json -->
       <form id="contact-form" action="/api/contact" method="POST" class="generated-form contact-form">
-        <div class="form-group">
+        <div class="form-row">
           <label for="name">Nom</label>
           <input id="name" type="text" name="name" placeholder="Votre nom" class="form-input" required/>
         </div>
-        <div class="form-group">
+        <div class="form-row">
           <label for="email">Email</label>
           <input id="email" type="email" name="email" placeholder="Votre email" class="form-input" required/>
         </div>
-        <div class="form-group">
+        <div class="form-row">
           <label for="message">Message</label>
           <textarea id="message" name="message" placeholder="Votre message" class="form-textarea" required></textarea>
         </div>
         <button type="submit" class="btn">Envoyer</button>
       </form>
+      <p class="form-status"></p>
     </div>
   </section>
 

--- a/script.js
+++ b/script.js
@@ -8,9 +8,13 @@ navToggle.addEventListener('click', () => {
 
 // Contact form handler
 const contactForm = document.querySelector('#contact-form');
+const formStatus = document.querySelector('.form-status');
 if (contactForm) {
   contactForm.addEventListener('submit', async (e) => {
     e.preventDefault();
+
+    formStatus.textContent = '';
+    formStatus.classList.remove('success', 'error');
 
     const formData = new FormData(contactForm);
     try {
@@ -23,11 +27,13 @@ if (contactForm) {
         throw new Error('Erreur réseau');
       }
 
-      alert('Message envoyé !');
+      formStatus.textContent = 'Message envoyé !';
+      formStatus.classList.add('success');
       contactForm.reset();
     } catch (err) {
       console.error(err);
-      alert("Une erreur est survenue lors de l'envoi du message.");
+      formStatus.textContent = "Une erreur est survenue lors de l'envoi du message.";
+      formStatus.classList.add('error');
     }
   });
 }

--- a/style.css
+++ b/style.css
@@ -234,6 +234,10 @@ section:nth-of-type(even) {
   gap: 1rem;
   max-width: 600px;
   margin: 0 auto;
+  background: #fff;
+  padding: 2rem;
+  border-radius: var(--radius);
+  box-shadow: 0 4px 10px rgba(0,0,0,.1);
 }
 .contact-form input,
 .contact-form textarea {
@@ -242,9 +246,27 @@ section:nth-of-type(even) {
   border-radius: var(--radius);
   font-family: inherit;
 }
-.contact-form button {
+.contact-form .btn {
+  width: 100%;
+  background: var(--secondary);
   border: none;
   cursor: pointer;
+}
+.contact-form .btn:hover {
+  background: #2c7a7b;
+  box-shadow: 0 8px 16px rgba(0,0,0,.15);
+}
+
+.form-status {
+  margin-top: 1rem;
+  font-weight: 600;
+  text-align: center;
+}
+.form-status.success {
+  color: #38a169;
+}
+.form-status.error {
+  color: #e53e3e;
 }
 
 /* About pillars */
@@ -275,7 +297,7 @@ section:nth-of-type(even) {
   box-shadow: 0 4px 10px rgba(0,0,0,.05);
 }
 /* Generated form styles */
-.generated-form .form-group {
+.generated-form .form-row {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;


### PR DESCRIPTION
## Summary
- Reorganize contact form fields using `.form-row` and add status message element
- Add card-like style for contact form and secondary full-width submit button with hover effect
- Display success or error messages inline instead of alerts

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/freelance_website/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68b49f85ced883299154da6ec217349e