### PR TITLE
Add discovery links to service cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,6 +85,7 @@
           <img src="images/generated/audit.svg" alt="Audit SEO avancé" />
           <h3>Audit SEO avancé</h3>
           <p>Analyse technique, sémantique et concurrentielle, enrichie par l’analyse de données pour identifier les freins et prioriser les meilleures opportunités de croissance.</p>
+          <a class="btn btn-light" href="/audit-seo-avance">Découvrir</a>
         </article>
         <article class="card" role="button" tabindex="0" aria-label="Optimisation technique et performance">
           <img src="images/generated/optimisation.svg" alt="Optimisation technique et performance" />
@@ -92,6 +93,7 @@
           <p>Structure, vitesse de chargement, indexation.</p>
           <p>Monitoring automatisé pour détecter les problèmes rapidement.</p>
           <p>Amélioration des Core Web Vitals et de l’expérience utilisateur.</p>
+          <a class="btn btn-light" href="/optimisation-technique-performance">Découvrir</a>
         </article>
         <article class="card" role="button" tabindex="0" aria-label="Stratégie de contenu et analyse sémantique">
           <img src="images/generated/contenu.svg" alt="Stratégie de contenu" />
@@ -99,18 +101,21 @@
           <p>Optimisation éditoriale basée sur les intentions de recherche.</p>
           <p>Détection et couverture des “semantic gaps” grâce à l’analyse de données.</p>
           <p>Recommandations de contenu orientées visibilité et engagement.</p>
+          <a class="btn btn-light" href="/strategie-contenu-analyse-semantique">Découvrir</a>
         </article>
         <article class="card" role="button" tabindex="0" aria-label="Netlinking et autorité">
           <img src="images/generated/netlinking.svg" alt="Netlinking et autorité" />
           <h3>Netlinking &amp; autorité</h3>
           <p>Développement d’un profil de liens naturel et pertinent.</p>
           <p>Identification des meilleures opportunités via la data et l’analyse concurrentielle.</p>
+          <a class="btn btn-light" href="/netlinking-autorite">Découvrir</a>
         </article>
         <article class="card" role="button" tabindex="0" aria-label="Référencement local">
           <img src="images/generated/local.svg" alt="Référencement local" />
           <h3>Référencement local</h3>
           <p>Optimisation de votre Google Business Profile.</p>
           <p>Contenus géolocalisés et signaux locaux pour améliorer la visibilité de proximité.</p>
+          <a class="btn btn-light" href="/referencement-local">Découvrir</a>
         </article>
         <article class="card" role="button" tabindex="0" aria-label="Automatisation et reporting SEO">
           <img src="images/generated/automatisation-reporting.svg" alt="Automatisation et reporting SEO" />
@@ -118,6 +123,7 @@
           <p>Création de scripts Python / workflows pour accélérer le suivi et gagner du temps.</p>
           <p>Mise en place de dashboards clairs pour suivre vos KPI SEO.</p>
           <p>Centralisation des données pour faciliter la prise de décision.</p>
+          <a class="btn btn-light" href="/automatisation-reporting-seo">Découvrir</a>
         </article>
       </div>
     </div>

--- a/style.css
+++ b/style.css
@@ -170,9 +170,14 @@ section:nth-of-type(even) {
   padding: 2rem 1.5rem;
   border-radius: var(--radius);
   box-shadow: 0 4px 10px rgba(0,0,0,.05);
+  display: flex;
+  flex-direction: column;
 }
 .card h3 {
   margin-top: 1rem;
+}
+.card .btn {
+  margin-top: auto;
 }
 
 /* Methodology */


### PR DESCRIPTION
## Summary
- add "Découvrir" buttons to each service card with links to detailed pages
- use flexbox so card buttons stick to the bottom

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b49f81f6c483298faac1dec377580f