### PR TITLE
refactor: two-column about section

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,30 +48,14 @@
 
   <!-- About -->
   <section id="about" class="section about">
-    <div class="container">
-      <h2 class="section-title">À propos de moi</h2>
-      <p>Je suis Marc Williame, consultant SEO indépendant en Belgique. Passionné par la data et les méthodes rigoureuses, j’ai choisi de me spécialiser dans un SEO précis, mesurable et orienté performance.</p>
-      <div class="pillars">
-        <article class="pillar">
-          <h3>SEO technique &amp; sémantique</h3>
-          <p>Audit, optimisation, contenu, netlinking, référencement local.</p>
-        </article>
-        <article class="pillar">
-          <h3>Automatisation SEO</h3>
-          <p>Scripts et workflows pour accélérer le crawl, le suivi des positions ou l’analyse du maillage interne.</p>
-        </article>
-        <article class="pillar">
-          <h3>Suivi &amp; mesure</h3>
-          <p>Création de dashboards personnalisés pour interpréter vos KPI et prioriser les actions.</p>
-        </article>
-        <article class="pillar">
-          <h3>Analyse sémantique avancée</h3>
-          <p>Détection des opportunités manquantes, identification des “semantic gaps” et structuration des contenus.</p>
-        </article>
-        <article class="pillar">
-          <h3>IA appliquée au SEO</h3>
-          <p>Observation et adaptation face aux changements liés aux moteurs de recherche augmentés par IA (ex. AI Overviews).</p>
-        </article>
+    <div class="container about-layout">
+      <div class="about-text">
+        <h2 class="section-title">À propos de moi</h2>
+        <p>Je suis Marc Williame, consultant SEO indépendant en Belgique. Passionné par la data et les méthodes rigoureuses, j’ai choisi de me spécialiser dans un SEO précis, mesurable et orienté performance.</p>
+        <a href="/presentation" class="btn">En savoir plus</a>
+      </div>
+      <div class="about-photo">
+        <img src="images/portrait.jpg" alt="Portrait de Marc Williame">
       </div>
     </div>
   </section>

--- a/style.css
+++ b/style.css
@@ -254,9 +254,20 @@ section:nth-of-type(even) {
   margin-bottom: 1rem;
 }
 
+/* About */
+.about-layout {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  align-items: center;
+}
+
 /* Responsive */
 @media (max-width: 768px) {
   .footer .container {
+    grid-template-columns: 1fr;
+  }
+  .about-layout {
     grid-template-columns: 1fr;
   }
   .nav ul {
@@ -323,19 +334,6 @@ section:nth-of-type(even) {
 }
 
 /* About pillars */
-.about .pillars {
-  display: grid;
-  gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  margin-top: 2rem;
-}
-.pillar {
-  background: #fff;
-  padding: 1.5rem;
-  border-radius: var(--radius);
-  box-shadow: 0 4px 10px rgba(0,0,0,.05);
-}
-
 /* Tools section */
 .tools .tool {
   display: flex;


### PR DESCRIPTION
## Summary
- replace About section with two-column grid including placeholder portrait
- add button linking to full presentation
- implement responsive grid layout for About section

## Testing
- `npx -y html-validate index.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b4afec04b883298f6bab56fe9cb6db