### PR TITLE
Refine services grid and icons for mobile clarity

### DIFF
--- a/style.css
+++ b/style.css
@@ -161,8 +161,12 @@ section:nth-of-type(even) {
 /* Services */
 .services .cards {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  grid-template-columns: repeat(3, 1fr);
   gap: 2rem;
+}
+.services .card img {
+  max-width: 80px;
+  margin: 0 auto 1rem;
 }
 .card {
   background: #fff;
@@ -268,6 +272,9 @@ section:nth-of-type(even) {
     grid-template-columns: 1fr;
   }
   .about-layout {
+    grid-template-columns: 1fr;
+  }
+  .services .cards {
     grid-template-columns: 1fr;
   }
   .nav ul {


### PR DESCRIPTION
## Summary
- Set services grid to three columns on large screens
- Constrain service icons to 80px and center them
- Stack service cards vertically on small screens for better responsiveness

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b54776f0c88329a7fa0c0b31adbf6c