### PR TITLE
Remove hero image and center hero text

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,9 +40,6 @@
         <p>Mon rôle d’expert SEO freelance : transformer vos données en actions concrètes pour générer plus de trafic qualifié et améliorer vos conversions.</p>
         <a href="#contact" class="btn btn-light">Parlons de votre projet</a>
       </div>
-      <div class="hero-img">
-        <img src="images/hero.svg" alt="Illustration consultant SEO" />
-      </div>
     </div>
   </section>
 

--- a/style.css
+++ b/style.css
@@ -127,20 +127,17 @@ a {
 }
 .hero-content {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  flex-wrap: wrap;
+  text-align: center;
 }
 .hero-text {
-  flex: 1 1 400px;
-  padding-right: 2rem;
+  flex: 1 1 auto;
+  padding-right: 0;
 }
 .hero-text h1 {
   font-size: 2.5rem;
   margin-top: 0;
-}
-.hero-img {
-  flex: 1 1 300px;
-  text-align: center;
 }
 
 /* Sections */


### PR DESCRIPTION
## Summary
- remove hero illustration container from hero section
- center hero heading and copy after removing image styling

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b54780a6a883299809f9c32b1b2538