### PR TITLE
Add clients logos section and update navigation

### DIFF
--- a/images/clients/client1.svg
+++ b/images/clients/client1.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="60">
+  <rect width="120" height="60" rx="8" fill="#0A84FF"/>
+  <text x="50%" y="50%" fill="#fff" font-size="14" font-family="Arial, sans-serif" dominant-baseline="middle" text-anchor="middle">Client 1</text>
+</svg>

--- a/images/clients/client2.svg
+++ b/images/clients/client2.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="60">
+  <rect width="120" height="60" rx="8" fill="#00C2CB"/>
+  <text x="50%" y="50%" fill="#fff" font-size="14" font-family="Arial, sans-serif" dominant-baseline="middle" text-anchor="middle">Client 2</text>
+</svg>

--- a/images/clients/client3.svg
+++ b/images/clients/client3.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="60">
+  <rect width="120" height="60" rx="8" fill="#1C1E26"/>
+  <text x="50%" y="50%" fill="#fff" font-size="14" font-family="Arial, sans-serif" dominant-baseline="middle" text-anchor="middle">Client 3</text>
+</svg>

--- a/images/clients/client4.svg
+++ b/images/clients/client4.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="120" height="60">
+  <rect width="120" height="60" rx="8" fill="#E9EFF5"/>
+  <text x="50%" y="50%" fill="#1C1E26" font-size="14" font-family="Arial, sans-serif" dominant-baseline="middle" text-anchor="middle">Client 4</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
           <li><a href="#about">À propos</a></li>
           <li><a href="#services">Services</a></li>
           <li><a href="#process">Méthodologie</a></li>
-          <li><a href="#why">Pourquoi moi&nbsp;?</a></li>
+          <li><a href="#clients">Clients</a></li>
           <li><a href="#tools">Outils</a></li>
           <li><a href="#faq">FAQ</a></li>
           <li><a href="#contact" class="btn">Contact</a></li>
@@ -167,27 +167,15 @@
     </div>
   </section>
 
-  <!-- Why Me -->
-  <section id="why" class="section why">
+  <!-- Clients -->
+  <section id="clients" class="section clients">
     <div class="container">
-      <h2 class="section-title">Pourquoi choisir un consultant SEO indépendant&nbsp;?</h2>
-      <div class="reasons">
-        <article class="reason">
-          <h3>Expertise SEO axée data</h3>
-          <p>Un travail précis, mesurable et basé sur vos données réelles.</p>
-        </article>
-        <article class="reason">
-          <h3>Approche sur mesure</h3>
-          <p>Chaque stratégie s’adapte à votre secteur et à vos ressources.</p>
-        </article>
-        <article class="reason">
-          <h3>Transparence &amp; pédagogie</h3>
-          <p>Reporting clair et accompagnement compréhensible.</p>
-        </article>
-        <article class="reason">
-          <h3>Vision durable</h3>
-          <p>Un SEO conçu pour rester solide face aux évolutions des moteurs de recherche.</p>
-        </article>
+      <h2 class="section-title">Ils me font confiance</h2>
+      <div class="logos">
+        <img src="images/clients/client1.svg" alt="Client 1" />
+        <img src="images/clients/client2.svg" alt="Client 2" />
+        <img src="images/clients/client3.svg" alt="Client 3" />
+        <img src="images/clients/client4.svg" alt="Client 4" />
       </div>
     </div>
   </section>
@@ -264,7 +252,7 @@
           <li><a href="#about">À propos</a></li>
           <li><a href="#services">Services</a></li>
           <li><a href="#process">Méthodologie</a></li>
-          <li><a href="#why">Pourquoi moi&nbsp;?</a></li>
+          <li><a href="#clients">Clients</a></li>
           <li><a href="#tools">Outils</a></li>
           <li><a href="#faq">FAQ</a></li>
           <li><a href="#contact">Contact</a></li>

--- a/style.css
+++ b/style.css
@@ -375,20 +375,17 @@ section:nth-of-type(even) {
   min-height: 120px;
 }
 
-/* Why section */
-.why .reasons {
+/* Clients */
+.clients .logos {
   display: grid;
-  gap: 1.5rem;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  max-width: 1000px;
-  margin: 0 auto;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  align-items: center;
+  justify-items: center;
 }
-.reason {
-  background: #fff;
-  padding: 1.5rem;
-  border-radius: var(--radius);
-  box-shadow: 0 4px 10px rgba(0,0,0,.05);
-  text-align: center;
+.clients .logos img {
+  max-width: 120px;
+  height: auto;
 }
 
 /* FAQ */


### PR DESCRIPTION
## Summary
- remove "why" section from home page
- add client logo grid section and corresponding styles
- update navigation links and include placeholder client logos

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b54783c7088329bc07b86c43042ebb