### PR TITLE
Reorder homepage sections for better flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,13 +17,13 @@
       <div class="logo">Consultant<strong>SEO</strong></div>
       <nav class="nav">
         <ul>
-          <li><a href="#about">À propos</a></li>
           <li><a href="#services">Services</a></li>
+          <li><a href="#contact" class="btn">Contact</a></li>
+          <li><a href="#about">À propos</a></li>
+          <li><a href="#tools">Outils</a></li>
           <li><a href="#process">Méthodologie</a></li>
           <li><a href="#clients">Clients</a></li>
-          <li><a href="#tools">Outils</a></li>
           <li><a href="#faq">FAQ</a></li>
-          <li><a href="#contact" class="btn">Contact</a></li>
         </ul>
         <button class="nav-toggle" aria-label="menu">&#9776;</button>
       </nav>
@@ -39,26 +39,6 @@
         <p>Vous cherchez un consultant SEO capable d’aller au-delà des recommandations classiques ? J’accompagne les entreprises à développer leur visibilité grâce à une approche qui combine SEO stratégique, analyse de données, automatisation et suivi précis des performances.</p>
         <p>Mon rôle d’expert SEO freelance : transformer vos données en actions concrètes pour générer plus de trafic qualifié et améliorer vos conversions.</p>
         <a href="#contact" class="btn btn-light">Parlons de votre projet</a>
-      </div>
-    </div>
-  </section>
-
-  <!-- About -->
-  <section id="about" class="section about">
-    <div class="container about-layout">
-      <div class="about-text">
-        <h2 class="section-title">À propos de moi</h2>
-        <p>Je suis Marc Williame, consultant SEO indépendant en Belgique. Ma démarche s'appuie sur la data, l'automatisation et une veille continue pour piloter des actions SEO mesurables et durables. Mon objectif : transformer vos données en leviers de croissance.</p>
-        <ul class="about-points">
-          <li>Analyses précises basées sur vos données et vos objectifs.</li>
-          <li>Automatisation pour gagner du temps et fiabiliser le suivi.</li>
-          <li>Conseils transparents et pédagogiques pour une mise en œuvre efficace.</li>
-          <li>Stratégies pensées pour une croissance durable.</li>
-        </ul>
-        <a href="/presentation" class="btn">En savoir plus</a>
-      </div>
-      <div class="about-photo">
-        <img src="images/portrait.jpg" alt="Portrait de Marc Williame">
       </div>
     </div>
   </section>
@@ -138,6 +118,26 @@
         <button type="submit" class="btn">Envoyer</button>
       </form>
       <p class="form-status"></p>
+    </div>
+  </section>
+
+  <!-- About -->
+  <section id="about" class="section about">
+    <div class="container about-layout">
+      <div class="about-text">
+        <h2 class="section-title">À propos de moi</h2>
+        <p>Je suis Marc Williame, consultant SEO indépendant en Belgique. Ma démarche s'appuie sur la data, l'automatisation et une veille continue pour piloter des actions SEO mesurables et durables. Mon objectif : transformer vos données en leviers de croissance.</p>
+        <ul class="about-points">
+          <li>Analyses précises basées sur vos données et vos objectifs.</li>
+          <li>Automatisation pour gagner du temps et fiabiliser le suivi.</li>
+          <li>Conseils transparents et pédagogiques pour une mise en œuvre efficace.</li>
+          <li>Stratégies pensées pour une croissance durable.</li>
+        </ul>
+        <a href="/presentation" class="btn">En savoir plus</a>
+      </div>
+      <div class="about-photo">
+        <img src="images/portrait.jpg" alt="Portrait de Marc Williame">
+      </div>
     </div>
   </section>
 
@@ -252,13 +252,13 @@
       <div class="footer-col">
         <div class="footer-logo">Marc Williame</div>
         <ul>
-          <li><a href="#about">À propos</a></li>
           <li><a href="#services">Services</a></li>
+          <li><a href="#contact">Contact</a></li>
+          <li><a href="#about">À propos</a></li>
+          <li><a href="#tools">Outils</a></li>
           <li><a href="#process">Méthodologie</a></li>
           <li><a href="#clients">Clients</a></li>
-          <li><a href="#tools">Outils</a></li>
           <li><a href="#faq">FAQ</a></li>
-          <li><a href="#contact">Contact</a></li>
         </ul>
       </div>
       <div class="footer-col">


### PR DESCRIPTION
## Summary
- Move Services section directly after hero and surface contact and about sections accordingly
- Reorder navigation and footer links to match new section order

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bec9c2e03c8329ae3c026324c3838d