### PR TITLE
feat: add CTA and simplify footer layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -245,32 +245,27 @@
     </div>
   </section>
 
-  <div class="container faq-contact-cta">
-    <a href="#contact" class="btn">Contactez-moi</a>
-  </div>
+  <!-- CTA -->
+  <section class="cta">
+    <div class="container">
+      <h2>Prêt à booster votre SEO&nbsp;?</h2>
+      <a href="#contact" class="btn btn-light">Discutons-en</a>
+    </div>
+  </section>
 
   <!-- Footer -->
   <footer class="footer">
     <div class="container">
-      <div class="footer-col">
+      <div class="footer-top">
         <div class="footer-logo">Marc Williame</div>
-        <ul>
+        <ul class="footer-nav">
           <li><a href="#services">Services</a></li>
-          <li><a href="#contact">Contact</a></li>
           <li><a href="#about">À propos</a></li>
-          <li><a href="#tools">Outils</a></li>
-          <li><a href="#process">Méthodologie</a></li>
-          <li><a href="#clients">Clients</a></li>
-          <li><a href="#faq">FAQ</a></li>
+          <li><a href="#contact">Contact</a></li>
         </ul>
       </div>
-      <div class="footer-col">
-        <p>Marc Williame<br>Bruxelles, Belgique</p>
-        <p><a href="mailto:contact@example.com">contact@example.com</a></p>
-      </div>
-      <div class="footer-col">
+      <div class="footer-bottom">
         <p>&copy; 2025 Marc Williame. Tous droits réservés.</p>
-        <p><a href="/mentions-legales">Mentions légales</a><br><a href="/politique-confidentialite">Politique de confidentialité</a></p>
       </div>
     </div>
   </footer>

--- a/style.css
+++ b/style.css
@@ -235,25 +235,46 @@ section:nth-of-type(even) {
   text-decoration: underline;
 }
 
-/* Footer */
-.footer {
-  background: var(--primary-dark);
+/* CTA */
+.cta {
+  background: linear-gradient(135deg, #1f2937, #0f172a);
   color: #fff;
   text-align: center;
-  padding: 1.5rem 0;
-  font-size: .9rem;
+  padding: 3rem 0;
 }
-.footer .container {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 2rem;
+.cta h2 {
+  margin: 0 0 1rem;
 }
-.footer-col {
-  text-align: left;
+
+/* Footer */
+.footer {
+  background: #111827;
+  color: #fff;
+  padding: 2rem 0;
+}
+.footer a {
+  color: #fff;
+}
+.footer-top {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
 }
 .footer-logo {
   font-weight: 700;
-  margin-bottom: 1rem;
+}
+.footer-nav {
+  list-style: none;
+  display: flex;
+  gap: 1.5rem;
+  margin: 0;
+  padding: 0;
+}
+.footer-bottom {
+  margin-top: 1.5rem;
+  text-align: center;
+  font-size: .9rem;
 }
 
 /* About */
@@ -275,8 +296,10 @@ section:nth-of-type(even) {
 
 /* Responsive */
 @media (max-width: 768px) {
-  .footer .container {
-    grid-template-columns: 1fr;
+  .footer-nav {
+    flex-direction: column;
+    gap: 0.75rem;
+    align-items: center;
   }
   .about-layout {
     grid-template-columns: 1fr;
@@ -469,8 +492,3 @@ section:nth-of-type(even) {
   padding-bottom: 1rem;
 }
 
-/* Call-to-action after FAQ */
-.faq-contact-cta {
-  text-align: center;
-  padding: 2rem 0;
-}


### PR DESCRIPTION
## Summary
- add dark gradient CTA section encouraging contact
- redesign footer with minimal nav and centered copyright
- style CTA and footer with dark palette and responsive tweaks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bed611b64083298c03c05a3a7c310c