### PR TITLE
Add dark and gradient service cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,6 +96,30 @@
     </div>
   </section>
 
+  <!-- Services en mode sombre -->
+  <section id="services-plus" class="section services services--alt">
+    <div class="container">
+      <h2 class="section-title">Services data &amp; IA</h2>
+      <div class="cards cards--alt">
+        <article class="card card--dark" role="button" tabindex="0" aria-label="Tableaux de bord">
+          <img src="images/generated/methodologie.svg" alt="Tableaux de bord" />
+          <h3>Tableaux de bord</h3>
+          <p>Visualisation de vos données SEO pour des décisions éclairées.</p>
+        </article>
+        <article class="card card--gradient" role="button" tabindex="0" aria-label="Automatisation IA">
+          <img src="images/generated/automatisation-reporting.svg" alt="Automatisation IA" />
+          <h3>Automatisation IA</h3>
+          <p>Scripts et workflows pour accélérer vos analyses.</p>
+        </article>
+        <article class="card card--dark" role="button" tabindex="0" aria-label="Stratégie data">
+          <img src="images/generated/audit.svg" alt="Stratégie data" />
+          <h3>Stratégie data</h3>
+          <p>Exploitation des données pour guider votre stratégie SEO.</p>
+        </article>
+      </div>
+    </div>
+  </section>
+
   <!-- Contact -->
   <section id="contact" class="section contact">
       <h2 class="section-title">Contact</h2>

--- a/style.css
+++ b/style.css
@@ -182,6 +182,31 @@ section:nth-of-type(even) {
   margin-top: auto;
 }
 
+/* Variantes de cartes sombres/gradient */
+.cards--alt {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 2rem;
+}
+
+.card--dark {
+  background: #1f2937;
+  color: #fff;
+}
+.card--dark:hover {
+  background: #111827;
+  box-shadow: 0 8px 16px rgba(0,0,0,0.3);
+}
+
+.card--gradient {
+  background: linear-gradient(135deg, #1e3a8a, #3b82f6);
+  color: #fff;
+}
+.card--gradient:hover {
+  background: linear-gradient(135deg, #1e40af, #2563eb);
+  box-shadow: 0 8px 16px rgba(0,0,0,0.3);
+}
+
 /* Methodology */
 .process {
   background: #1E3A8A;


### PR DESCRIPTION
## Summary
- add alternative services section with dark and gradient cards
- style new card variants with grid layout and hover contrast

## Testing
- `npx prettier -c index.html style.css` *(fails: Code style issues found)*
- `npx htmlhint index.html` *(fails: 403 Forbidden - cannot fetch package)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bed6113dbc8329b46e26ceccd107a0