### PR TITLE
Add collapsible details for services and FAQ

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,50 +49,62 @@
     <div class="container">
       <h2 class="section-title">Mes services en SEO</h2>
       <div class="cards">
-        <article class="card" role="button" tabindex="0" aria-label="Audit SEO avancé">
-          <img src="images/generated/audit.svg" alt="Audit SEO avancé" />
-          <h3>Audit SEO avancé</h3>
+        <details class="card">
+          <summary>
+            <img src="images/generated/audit.svg" alt="Audit SEO avancé" />
+            <h3>Audit SEO avancé</h3>
+          </summary>
           <p>Analyse technique, sémantique et concurrentielle, enrichie par l’analyse de données pour identifier les freins et prioriser les meilleures opportunités de croissance.</p>
           <a class="btn btn-light" href="/audit-seo-avance">Découvrir</a>
-        </article>
-        <article class="card" role="button" tabindex="0" aria-label="Optimisation technique et performance">
-          <img src="images/generated/optimisation.svg" alt="Optimisation technique et performance" />
-          <h3>Optimisation technique &amp; performance</h3>
+        </details>
+        <details class="card">
+          <summary>
+            <img src="images/generated/optimisation.svg" alt="Optimisation technique et performance" />
+            <h3>Optimisation technique &amp; performance</h3>
+          </summary>
           <p>Structure, vitesse de chargement, indexation.</p>
           <p>Monitoring automatisé pour détecter les problèmes rapidement.</p>
           <p>Amélioration des Core Web Vitals et de l’expérience utilisateur.</p>
           <a class="btn btn-light" href="/optimisation-technique-performance">Découvrir</a>
-        </article>
-        <article class="card" role="button" tabindex="0" aria-label="Stratégie de contenu et analyse sémantique">
-          <img src="images/generated/contenu.svg" alt="Stratégie de contenu" />
-          <h3>Stratégie de contenu &amp; analyse sémantique</h3>
+        </details>
+        <details class="card">
+          <summary>
+            <img src="images/generated/contenu.svg" alt="Stratégie de contenu" />
+            <h3>Stratégie de contenu &amp; analyse sémantique</h3>
+          </summary>
           <p>Optimisation éditoriale basée sur les intentions de recherche.</p>
           <p>Détection et couverture des “semantic gaps” grâce à l’analyse de données.</p>
           <p>Recommandations de contenu orientées visibilité et engagement.</p>
           <a class="btn btn-light" href="/strategie-contenu-analyse-semantique">Découvrir</a>
-        </article>
-        <article class="card" role="button" tabindex="0" aria-label="Netlinking et autorité">
-          <img src="images/generated/netlinking.svg" alt="Netlinking et autorité" />
-          <h3>Netlinking &amp; autorité</h3>
+        </details>
+        <details class="card">
+          <summary>
+            <img src="images/generated/netlinking.svg" alt="Netlinking et autorité" />
+            <h3>Netlinking &amp; autorité</h3>
+          </summary>
           <p>Développement d’un profil de liens naturel et pertinent.</p>
           <p>Identification des meilleures opportunités via la data et l’analyse concurrentielle.</p>
           <a class="btn btn-light" href="/netlinking-autorite">Découvrir</a>
-        </article>
-        <article class="card" role="button" tabindex="0" aria-label="Référencement local">
-          <img src="images/generated/local.svg" alt="Référencement local" />
-          <h3>Référencement local</h3>
+        </details>
+        <details class="card">
+          <summary>
+            <img src="images/generated/local.svg" alt="Référencement local" />
+            <h3>Référencement local</h3>
+          </summary>
           <p>Optimisation de votre Google Business Profile.</p>
           <p>Contenus géolocalisés et signaux locaux pour améliorer la visibilité de proximité.</p>
           <a class="btn btn-light" href="/referencement-local">Découvrir</a>
-        </article>
-        <article class="card" role="button" tabindex="0" aria-label="Automatisation et reporting SEO">
-          <img src="images/generated/automatisation-reporting.svg" alt="Automatisation et reporting SEO" />
-          <h3>Automatisation &amp; reporting SEO</h3>
+        </details>
+        <details class="card">
+          <summary>
+            <img src="images/generated/automatisation-reporting.svg" alt="Automatisation et reporting SEO" />
+            <h3>Automatisation &amp; reporting SEO</h3>
+          </summary>
           <p>Création de scripts Python / workflows pour accélérer le suivi et gagner du temps.</p>
           <p>Mise en place de dashboards clairs pour suivre vos KPI SEO.</p>
           <p>Centralisation des données pour faciliter la prise de décision.</p>
           <a class="btn btn-light" href="/automatisation-reporting-seo">Découvrir</a>
-        </article>
+        </details>
       </div>
     </div>
   </section>
@@ -102,21 +114,27 @@
     <div class="container">
       <h2 class="section-title">Services data &amp; IA</h2>
       <div class="cards cards--alt">
-        <article class="card card--dark" role="button" tabindex="0" aria-label="Tableaux de bord">
-          <img src="images/generated/methodologie.svg" alt="Tableaux de bord" />
-          <h3>Tableaux de bord</h3>
+        <details class="card card--dark">
+          <summary>
+            <img src="images/generated/methodologie.svg" alt="Tableaux de bord" />
+            <h3>Tableaux de bord</h3>
+          </summary>
           <p>Visualisation de vos données SEO pour des décisions éclairées.</p>
-        </article>
-        <article class="card card--gradient" role="button" tabindex="0" aria-label="Automatisation IA">
-          <img src="images/generated/automatisation-reporting.svg" alt="Automatisation IA" />
-          <h3>Automatisation IA</h3>
+        </details>
+        <details class="card card--gradient">
+          <summary>
+            <img src="images/generated/automatisation-reporting.svg" alt="Automatisation IA" />
+            <h3>Automatisation IA</h3>
+          </summary>
           <p>Scripts et workflows pour accélérer vos analyses.</p>
-        </article>
-        <article class="card card--dark" role="button" tabindex="0" aria-label="Stratégie data">
-          <img src="images/generated/audit.svg" alt="Stratégie data" />
-          <h3>Stratégie data</h3>
+        </details>
+        <details class="card card--dark">
+          <summary>
+            <img src="images/generated/audit.svg" alt="Stratégie data" />
+            <h3>Stratégie data</h3>
+          </summary>
           <p>Exploitation des données pour guider votre stratégie SEO.</p>
-        </article>
+        </details>
       </div>
     </div>
   </section>
@@ -236,36 +254,26 @@
     <div class="container">
       <h2 class="section-title">FAQ – SEO, Data &amp; Automatisation</h2>
       <div class="accordion">
-        <div class="accordion-item">
-          <button class="accordion-title" aria-expanded="false" aria-controls="faq1">Quelle est la différence entre un consultant SEO et une agence&nbsp;?</button>
-          <div id="faq1" class="accordion-content" aria-hidden="true">
-            <p>Un consultant SEO indépendant apporte un accompagnement personnalisé, une grande flexibilité et une relation directe, là où une agence applique souvent des méthodes standardisées.</p>
-          </div>
-        </div>
-        <div class="accordion-item">
-          <button class="accordion-title" aria-expanded="false" aria-controls="faq2">Qu’est-ce qu’un expert SEO axé data&nbsp;?</button>
-          <div id="faq2" class="accordion-content" aria-hidden="true">
-            <p>C’est un consultant SEO qui s’appuie sur les données (trafic, positions, logs, conversions) pour guider ses recommandations et prioriser les actions.</p>
-          </div>
-        </div>
-        <div class="accordion-item">
-          <button class="accordion-title" aria-expanded="false" aria-controls="faq3">Pourquoi intégrer l’IA et l’automatisation dans le SEO&nbsp;?</button>
-          <div id="faq3" class="accordion-content" aria-hidden="true">
-            <p>Parce qu’elles permettent de gagner du temps sur les tâches répétitives et de se concentrer sur la stratégie. L’IA aide aussi à analyser de grands volumes de données pour mieux comprendre les opportunités.</p>
-          </div>
-        </div>
-        <div class="accordion-item">
-          <button class="accordion-title" aria-expanded="false" aria-controls="faq4">Combien de temps pour obtenir des résultats SEO&nbsp;?</button>
-          <div id="faq4" class="accordion-content" aria-hidden="true">
-            <p>Selon la concurrence et vos objectifs, les premiers effets apparaissent généralement après 3 à 6 mois. Le SEO reste une stratégie à long terme.</p>
-          </div>
-        </div>
-        <div class="accordion-item">
-          <button class="accordion-title" aria-expanded="false" aria-controls="faq5">Pouvez-vous mettre en place des dashboards SEO personnalisés&nbsp;?</button>
-          <div id="faq5" class="accordion-content" aria-hidden="true">
-            <p>Oui. Je propose des dashboards (Looker Studio, Notion, Google Sheets) qui centralisent vos KPI et rendent vos données facilement actionnables.</p>
-          </div>
-        </div>
+        <details>
+          <summary>Quelle est la différence entre un consultant SEO et une agence&nbsp;?</summary>
+          <p>Un consultant SEO indépendant apporte un accompagnement personnalisé, une grande flexibilité et une relation directe, là où une agence applique souvent des méthodes standardisées.</p>
+        </details>
+        <details>
+          <summary>Qu’est-ce qu’un expert SEO axé data&nbsp;?</summary>
+          <p>C’est un consultant SEO qui s’appuie sur les données (trafic, positions, logs, conversions) pour guider ses recommandations et prioriser les actions.</p>
+        </details>
+        <details>
+          <summary>Pourquoi intégrer l’IA et l’automatisation dans le SEO&nbsp;?</summary>
+          <p>Parce qu’elles permettent de gagner du temps sur les tâches répétitives et de se concentrer sur la stratégie. L’IA aide aussi à analyser de grands volumes de données pour mieux comprendre les opportunités.</p>
+        </details>
+        <details>
+          <summary>Combien de temps pour obtenir des résultats SEO&nbsp;?</summary>
+          <p>Selon la concurrence et vos objectifs, les premiers effets apparaissent généralement après 3 à 6 mois. Le SEO reste une stratégie à long terme.</p>
+        </details>
+        <details>
+          <summary>Pouvez-vous mettre en place des dashboards SEO personnalisés&nbsp;?</summary>
+          <p>Oui. Je propose des dashboards (Looker Studio, Notion, Google Sheets) qui centralisent vos KPI et rendent vos données facilement actionnables.</p>
+        </details>
       </div>
     </div>
   </section>

--- a/script.js
+++ b/script.js
@@ -38,27 +38,3 @@ if (contactForm) {
   });
 }
 
-// FAQ accordion
-const accordionItems = document.querySelectorAll('.accordion-item');
-accordionItems.forEach(item => {
-  const title = item.querySelector('.accordion-title');
-  const content = item.querySelector('.accordion-content');
-
-  title.addEventListener('click', () => {
-    const isExpanded = title.getAttribute('aria-expanded') === 'true';
-
-    accordionItems.forEach(i => {
-      const t = i.querySelector('.accordion-title');
-      const c = i.querySelector('.accordion-content');
-      t.setAttribute('aria-expanded', 'false');
-      c.setAttribute('aria-hidden', 'true');
-      i.classList.remove('active');
-    });
-
-    if (!isExpanded) {
-      title.setAttribute('aria-expanded', 'true');
-      content.setAttribute('aria-hidden', 'false');
-      item.classList.add('active');
-    }
-  });
-});

--- a/style.css
+++ b/style.css
@@ -36,6 +36,8 @@ h2 {
 p {
   font-size: 1rem;
   font-weight: 400;
+  max-width: 65ch;
+  margin: 1rem 0;
 }
 
 img {
@@ -186,6 +188,46 @@ section:nth-of-type(even) {
 }
 .card .btn {
   margin-top: auto;
+}
+
+/* Details / summary accordion */
+details {
+  background: #fff;
+  border-radius: var(--radius);
+  box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+  margin: 1rem 0;
+}
+
+summary {
+  list-style: none;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+
+summary::-webkit-details-marker {
+  display: none;
+}
+
+details p {
+  padding: 0 1rem 1rem;
+}
+
+/* FAQ */
+.faq details {
+  max-width: 800px;
+  margin: 0 auto 1.5rem;
+}
+
+.faq summary {
+  padding: 1rem 1.5rem;
+  font-weight: 500;
+}
+
+.faq details p {
+  padding: 0 1.5rem 1rem;
 }
 
 /* Variantes de cartes sombres/gradient */
@@ -470,56 +512,4 @@ section:nth-of-type(even) {
 }
 
 /* FAQ */
-.faq .accordion-item {
-  max-width: 800px;
-  margin: 0 auto 1.5rem;
-  background: var(--light);
-  border-radius: var(--radius);
-  overflow: hidden;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.05);
-  transition: background .3s, box-shadow .3s;
-}
-
-.faq .accordion-item:hover {
-  background: #fff;
-}
-
-.accordion-title {
-  width: 100%;
-  background: none;
-  border: none;
-  text-align: left;
-  padding: 1rem 1.5rem;
-  font-weight: 500;
-  cursor: pointer;
-  position: relative;
-}
-
-.accordion-title::after {
-  content: '';
-  position: absolute;
-  right: 1.5rem;
-  top: 50%;
-  width: 1rem;
-  height: 1rem;
-  transform: translateY(-50%) rotate(0deg);
-  background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='%230A84FF' stroke-width='2' viewBox='0 0 24 24'><polyline points='6 9 12 15 18 9'/></svg>") center/contain no-repeat;
-  transition: transform .3s;
-}
-
-.accordion-title[aria-expanded="true"]::after {
-  transform: translateY(-50%) rotate(180deg);
-}
-
-.accordion-content {
-  max-height: 0;
-  overflow: hidden;
-  transition: max-height .3s ease;
-  padding: 0 1.5rem;
-}
-
-.accordion-item.active .accordion-content {
-  max-height: 500px;
-  padding-bottom: 1rem;
-}
 


### PR DESCRIPTION
## Summary
- Convert service cards and FAQ items to `<details>/<summary>` to limit on-screen length
- Style details elements and paragraphs for readability
- Remove obsolete FAQ accordion script

## Testing
- `npm test` *(fails: command not found: npm)*

------
https://chatgpt.com/codex/tasks/task_e_68bede705f10832988256e124a2b31fc