### PR TITLE
Allow paragraphs to span full width

### DIFF
--- a/style.css
+++ b/style.css
@@ -36,7 +36,7 @@ h2 {
 p {
   font-size: 1rem;
   font-weight: 400;
-  max-width: 65ch;
+  max-width: 100%;
   margin: 1rem 0;
 }
 


### PR DESCRIPTION
## Summary
- Replace paragraph max-width constraint with 100% so text can use the entire container width

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c46ac6e3a883299650cb892f3eb8b1