### PR TITLE
Supprimer les détails/summary des cartes de services

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,54 +49,42 @@
       <p>En tant que consultant SEO freelance, j’ai choisi une approche orientée data et IA. Pas pour remplacer l’humain, mais pour libérer du temps, fiabiliser les analyses et transformer les données en décisions claires.</p>
       <p>Le référencement n’est pas seulement une question de mots-clés ou de backlinks : c’est un équilibre entre technique, contenu, autorité et expérience utilisateur. Mon rôle est de mettre de l’ordre dans cette complexité pour que vous puissiez vous concentrer sur ce qui compte : faire grandir votre projet.</p>
       <div class="cards">
-        <details class="card">
-          <summary>
-            <img src="images/generated/audit.svg" alt="Audit SEO avancé" />
-            <h3>Audit SEO avancé</h3>
-          </summary>
+        <div class="card">
+          <img src="images/generated/audit.svg" alt="Audit SEO avancé" />
+          <h3>Audit SEO avancé</h3>
           <p>Un audit, ce n’est pas une liste d’erreurs dans un fichier Excel. C’est une radiographie complète du site : indexation, architecture, performance, signaux techniques. L’objectif n’est pas de pointer des défauts, mais de comprendre comment le site est perçu par Google et où se trouvent les leviers concrets de progression.</p>
           <a class="btn btn-light" href="/audit-seo-avance">Découvrir</a>
-        </details>
-        <details class="card">
-          <summary>
-            <img src="images/generated/optimisation.svg" alt="Optimisation technique et performance" />
-            <h3>Optimisation technique &amp; performance</h3>
-          </summary>
+        </div>
+        <div class="card">
+          <img src="images/generated/optimisation.svg" alt="Optimisation technique et performance" />
+          <h3>Optimisation technique &amp; performance</h3>
           <p>Un site rapide et bien structuré n’est pas seulement apprécié des moteurs de recherche : c’est aussi une meilleure expérience pour vos utilisateurs. Ici, l’approche consiste à aligner performance technique et SEO : vitesse, mobile, Core Web Vitals, structure HTML.</p>
           <a class="btn btn-light" href="/optimisation-technique-performance">Découvrir</a>
-        </details>
-        <details class="card">
-          <summary>
-            <img src="images/generated/contenu.svg" alt="Stratégie de contenu" />
-            <h3>Stratégie de contenu &amp; analyse sémantique</h3>
-          </summary>
+        </div>
+        <div class="card">
+          <img src="images/generated/contenu.svg" alt="Stratégie de contenu" />
+          <h3>Stratégie de contenu &amp; analyse sémantique</h3>
           <p>Un contenu qui fonctionne n’est pas forcément le plus long, mais celui qui répond exactement à l’intention de recherche. Grâce à l’analyse sémantique et aux données issues de vos utilisateurs, il devient possible d’identifier les sujets à fort potentiel, de hiérarchiser vos pages et de construire une vraie architecture éditoriale.</p>
           <a class="btn btn-light" href="/strategie-contenu-analyse-semantique">Découvrir</a>
-        </details>
-        <details class="card">
-          <summary>
-            <img src="images/generated/netlinking.svg" alt="Netlinking et autorité" />
-            <h3>Netlinking &amp; autorité</h3>
-          </summary>
+        </div>
+        <div class="card">
+          <img src="images/generated/netlinking.svg" alt="Netlinking et autorité" />
+          <h3>Netlinking &amp; autorité</h3>
           <p>Les liens restent un pilier du SEO. Mais il ne s’agit pas d’en accumuler sans logique. Une bonne stratégie de netlinking, c’est créer un écosystème de confiance autour de votre site, en ciblant les bons partenariats, les bons contenus, et en renforçant la crédibilité de votre marque.</p>
           <a class="btn btn-light" href="/netlinking-autorite">Découvrir</a>
-        </details>
-        <details class="card">
-          <summary>
-            <img src="images/generated/local.svg" alt="Référencement local" />
-            <h3>Référencement local</h3>
-          </summary>
+        </div>
+        <div class="card">
+          <img src="images/generated/local.svg" alt="Référencement local" />
+          <h3>Référencement local</h3>
           <p>Être visible dans sa zone géographique, c’est souvent plus rentable que de chercher une visibilité mondiale. Le SEO local permet de capter des prospects proches, de renforcer votre présence dans Google Maps et d’optimiser vos fiches locales.</p>
           <a class="btn btn-light" href="/referencement-local">Découvrir</a>
-        </details>
-        <details class="card">
-          <summary>
-            <img src="images/generated/automatisation-reporting.svg" alt="Automatisation et reporting SEO" />
-            <h3>Automatisation &amp; reporting SEO</h3>
-          </summary>
+        </div>
+        <div class="card">
+          <img src="images/generated/automatisation-reporting.svg" alt="Automatisation et reporting SEO" />
+          <h3>Automatisation &amp; reporting SEO</h3>
           <p>Le SEO génère une montagne de données. Sans automatisation, on finit vite noyé. Tableaux de bord, alertes, suivi d’indexation, rapports automatiques : l’idée est de vous donner une vision claire et en temps réel de vos performances.</p>
           <a class="btn btn-light" href="/automatisation-reporting-seo">Découvrir</a>
-        </details>
+        </div>
       </div>
     </div>
   </section>
@@ -107,27 +95,21 @@
       <h2 class="section-title">Services data &amp; IA</h2>
       <p>Le SEO moderne dépasse le simple champ du contenu. Aujourd’hui, les projets les plus performants intègrent des briques data et IA :</p>
       <div class="cards cards--alt">
-        <details class="card card--dark">
-          <summary>
-            <img src="images/generated/methodologie.svg" alt="Tableaux de bord" />
-            <h3>Tableaux de bord</h3>
-          </summary>
+        <div class="card card--dark">
+          <img src="images/generated/methodologie.svg" alt="Tableaux de bord" />
+          <h3>Tableaux de bord</h3>
           <p>Visualisation de vos données SEO pour des décisions éclairées.</p>
-        </details>
-        <details class="card card--gradient">
-          <summary>
-            <img src="images/generated/automatisation-reporting.svg" alt="Automatisation IA" />
-            <h3>Automatisation IA</h3>
-          </summary>
+        </div>
+        <div class="card card--gradient">
+          <img src="images/generated/automatisation-reporting.svg" alt="Automatisation IA" />
+          <h3>Automatisation IA</h3>
           <p>Scripts et workflows pour accélérer vos analyses.</p>
-        </details>
-        <details class="card card--dark">
-          <summary>
-            <img src="images/generated/audit.svg" alt="Stratégie data" />
-            <h3>Stratégie data</h3>
-          </summary>
+        </div>
+        <div class="card card--dark">
+          <img src="images/generated/audit.svg" alt="Stratégie data" />
+          <h3>Stratégie data</h3>
           <p>Exploitation des données pour guider votre stratégie SEO.</p>
-        </details>
+        </div>
       </div>
     </div>
   </section>

--- a/style.css
+++ b/style.css
@@ -189,40 +189,24 @@ section:nth-of-type(even) {
   margin-top: auto;
 }
 
-/* Details / summary accordion */
-details {
-  background: #fff;
-  border-radius: var(--radius);
-  box-shadow: 0 2px 8px rgba(0,0,0,0.05);
-  margin: 1rem 0;
-}
-
-summary {
-  list-style: none;
-  cursor: pointer;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 1rem;
-}
-
-summary::-webkit-details-marker {
-  display: none;
-}
-
-details p {
-  padding: 0 1rem 1rem;
-}
-
 /* FAQ */
 .faq details {
   max-width: 800px;
   margin: 0 auto 1.5rem;
+  background: #fff;
+  border-radius: var(--radius);
+  box-shadow: 0 2px 8px rgba(0,0,0,0.05);
 }
 
 .faq summary {
   padding: 1rem 1.5rem;
   font-weight: 500;
+  list-style: none;
+  cursor: pointer;
+}
+
+.faq summary::-webkit-details-marker {
+  display: none;
 }
 
 .faq details p {


### PR DESCRIPTION
## Summary
- Remplacer les `<details>`/`<summary>` des sections Services par de simples `<div class="card">`
- Supprimer les styles globaux `details/summary` et restreindre ceux du FAQ

## Testing
- `npm test` *(échoue : no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c470cc10888329a12a71ce575e0032