### PR TITLE
feat: add hero background image

### DIFF
--- a/style.css
+++ b/style.css
@@ -118,17 +118,26 @@ a {
 
 /* Hero */
 .hero {
-  background: linear-gradient(135deg, #3B82F6, #8B5CF6);
+  background: url("images/6c6a1684-6c34-42d6-9359-10cdd421a895.png") center/cover no-repeat;
   color: #fff;
   padding: 6rem 0;
   position: relative;
   overflow: hidden;
 }
+
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+}
+
 .hero-content {
   display: flex;
   align-items: center;
   justify-content: space-between;
   position: relative;
+  z-index: 1;
 }
 .hero-text {
   max-width: 600px;


### PR DESCRIPTION
## Summary
- use background image for hero section
- add dark overlay to improve text legibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c470c9d7c88329a382a9739da5da23