### PR TITLE
Add discovery buttons to data & AI service cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,16 +99,19 @@
           <img src="images/generated/methodologie.svg" alt="Tableaux de bord" />
           <h3>Tableaux de bord</h3>
           <p>Visualisation de vos données SEO pour des décisions éclairées.</p>
+          <a class="btn btn-light" href="/tableaux-de-bord">Découvrir</a>
         </div>
         <div class="card card--gradient">
           <img src="images/generated/automatisation-reporting.svg" alt="Automatisation IA" />
           <h3>Automatisation IA</h3>
           <p>Scripts et workflows pour accélérer vos analyses.</p>
+          <a class="btn btn-light" href="/automatisation-ia">Découvrir</a>
         </div>
         <div class="card card--dark">
           <img src="images/generated/audit.svg" alt="Stratégie data" />
           <h3>Stratégie data</h3>
           <p>Exploitation des données pour guider votre stratégie SEO.</p>
+          <a class="btn btn-light" href="/strategie-data">Découvrir</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add `Découvrir` links to each Data & IA service card
- verify existing card and `cards--alt` styles handle button layout without additional CSS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4753f07d8832997072cf45be3c0b3