### PR TITLE
add strategie data page

### DIFF
--- a/strategie-data/index.html
+++ b/strategie-data/index.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Stratégie data-driven SEO | Consultant SEO freelance</title>
+  <meta name="description" content="De la collecte de données à la modélisation, construisez une roadmap SEO guidée par vos données." />
+  <link rel="stylesheet" href="../style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Space+Grotesk:wght@700&display=swap" rel="stylesheet">
+  <script defer src="../script.js"></script>
+</head>
+<body>
+  <!-- Header / Navigation -->
+  <header class="header">
+    <div class="container">
+      <div class="logo">Consultant<strong>SEO</strong></div>
+      <nav class="nav">
+        <ul>
+          <li><a href="/#services">Services</a></li>
+          <li><a href="/#contact" class="btn">Contact</a></li>
+          <li><a href="/#about">À propos</a></li>
+          <li><a href="/#tools">Outils</a></li>
+          <li><a href="/#process">Méthodologie</a></li>
+          <li><a href="/#clients">Clients</a></li>
+          <li><a href="/#faq">FAQ</a></li>
+        </ul>
+        <button class="nav-toggle" aria-label="menu">&#9776;</button>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero">
+      <div class="container hero-content">
+        <div class="hero-text">
+          <h1>Stratégie data-driven</h1>
+          <p class="hero-subtitle">Faire parler vos données pour guider chaque décision SEO.</p>
+          <a href="/#contact" class="btn btn-light">Parlons de vos données</a>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <h2 class="section-title">Faire parler vos données</h2>
+        <p>Les données brutes ne valent que par les questions que l'on se pose. L’objectif est d’extraire des signaux exploitables pour orienter votre référencement.</p>
+      </div>
+    </section>
+
+    <section class="section section--alt">
+      <div class="container">
+        <h2 class="section-title">Collecte &amp; préparation</h2>
+        <p>Centralisation des sources, nettoyage et mise en forme des jeux de données pour des analyses fiables.</p>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <h2 class="section-title">Modélisation &amp; insight SEO</h2>
+        <p>Analyses statistiques et modèles sur mesure pour transformer vos données en décisions SEO actionnables.</p>
+      </div>
+    </section>
+
+    <section class="section section--alt">
+      <div class="container">
+        <h2 class="section-title">Roadmap data-driven</h2>
+        <p>Priorisation des actions et suivi des performances pour une stratégie SEO réellement pilotée par les données.</p>
+      </div>
+    </section>
+  </main>
+
+  <section class="cta">
+    <div class="container">
+      <h2>Prêt à lancer votre stratégie data&nbsp;?</h2>
+      <a href="/#contact" class="btn btn-light">Contactez-moi</a>
+    </div>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-top">
+        <div class="footer-logo">Marc Williame</div>
+        <ul class="footer-nav">
+          <li><a href="/#services">Services</a></li>
+          <li><a href="/#about">À propos</a></li>
+          <li><a href="/#contact">Contact</a></li>
+        </ul>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; 2025 Marc Williame. Tous droits réservés.</p>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create dedicated stratégie data page with common header and footer
- add sections highlighting data collection, modeling, and roadmap

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4753e51f08329bb32ffb2ee315eec