### PR TITLE
Add automation reporting SEO page

### DIFF
--- a/automatisation-reporting-seo/index.html
+++ b/automatisation-reporting-seo/index.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Automatisation &amp; reporting SEO | Consultant data &amp; IA</title>
+  <meta name="description" content="Automatisez votre reporting SEO grâce aux dashboards, alertes et scripts de monitoring. Livrables personnalisés et formation.">
+  <link rel="stylesheet" href="../style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Space+Grotesk:wght@700&display=swap" rel="stylesheet">
+  <script defer src="../script.js"></script>
+</head>
+<body>
+  <header class="header">
+    <div class="container">
+      <div class="logo">Consultant<strong>SEO</strong></div>
+      <nav class="nav">
+        <ul>
+          <li><a href="/#services">Services</a></li>
+          <li><a href="/#contact" class="btn">Contact</a></li>
+          <li><a href="/#about">À propos</a></li>
+          <li><a href="/#tools">Outils</a></li>
+          <li><a href="/#process">Méthodologie</a></li>
+          <li><a href="/#clients">Clients</a></li>
+          <li><a href="/#faq">FAQ</a></li>
+        </ul>
+        <button class="nav-toggle" aria-label="menu">&#9776;</button>
+      </nav>
+    </div>
+  </header>
+  <section class="hero">
+    <div class="container hero-content">
+      <div class="hero-text">
+        <h1>Automatisation &amp; reporting SEO</h1>
+        <p class="hero-subtitle">Tableaux de bord, alertes et scripts pour suivre vos performances sans effort.</p>
+        <a href="/#contact" class="btn btn-light">Parlons de votre projet</a>
+      </div>
+    </div>
+  </section>
+  <section class="section">
+    <div class="container">
+      <h2 class="section-title">Pourquoi automatiser&nbsp;?</h2>
+      <p>Le SEO génère une quantité massive de données. L’automatisation permet de se concentrer sur l’analyse et la stratégie plutôt que sur la collecte manuelle.</p>
+    </div>
+  </section>
+  <section class="section services">
+    <div class="container">
+      <h2 class="section-title">Dashboards &amp; alerting</h2>
+      <p>Création de tableaux de bord sur mesure et mise en place d’alertes pour détecter les anomalies avant qu’elles n’impactent votre trafic.</p>
+    </div>
+  </section>
+  <section class="section services services--alt">
+    <div class="container">
+      <h2 class="section-title">Scripts de monitoring</h2>
+      <p>Développement de scripts pour surveiller l’indexation, les performances ou les changements techniques de votre site.</p>
+    </div>
+  </section>
+  <section class="section services">
+    <div class="container">
+      <h2 class="section-title">Livrables et formation</h2>
+      <p>Remise de livrables documentés et sessions de formation pour rendre vos équipes autonomes sur les outils créés.</p>
+    </div>
+  </section>
+  <section class="cta">
+    <div class="container">
+      <h2>Envie d’automatiser votre SEO&nbsp;?</h2>
+      <a href="/#contact" class="btn btn-light">Contactez-moi</a>
+    </div>
+  </section>
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-top">
+        <div class="footer-logo">Marc Williame</div>
+        <ul class="footer-nav">
+          <li><a href="/#services">Services</a></li>
+          <li><a href="/#about">À propos</a></li>
+          <li><a href="/#contact">Contact</a></li>
+        </ul>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; 2025 Marc Williame. Tous droits réservés.</p>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Create dedicated automation and reporting SEO page with header and footer
- Describe benefits, dashboards, monitoring scripts, and training deliverables
- Add call-to-action linking to home contact section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4753b8b008329837de17568e82405