### PR TITLE
Add netlinking authority service page

### DIFF
--- a/netlinking-autorite/index.html
+++ b/netlinking-autorite/index.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Netlinking & Autorité — Stratégie de liens SEO</title>
+  <meta name="description" content="Approche experte du netlinking pour renforcer l’autorité de votre site : sélection de domaines, suivi des indicateurs et gestion des risques." />
+  <link rel="stylesheet" href="../style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Space+Grotesk:wght@700&display=swap" rel="stylesheet">
+  <script defer src="../script.js"></script>
+</head>
+<body>
+  <!-- Header / Navigation -->
+  <header class="header">
+    <div class="container">
+      <div class="logo">Consultant<strong>SEO</strong></div>
+      <nav class="nav">
+        <ul>
+          <li><a href="/#services">Services</a></li>
+          <li><a href="/#contact" class="btn">Contact</a></li>
+          <li><a href="/#about">À propos</a></li>
+          <li><a href="/#tools">Outils</a></li>
+          <li><a href="/#process">Méthodologie</a></li>
+          <li><a href="/#clients">Clients</a></li>
+          <li><a href="/#faq">FAQ</a></li>
+        </ul>
+        <button class="nav-toggle" aria-label="menu">&#9776;</button>
+      </nav>
+    </div>
+  </header>
+
+  <section class="section">
+    <div class="container">
+      <h1>Netlinking &amp; Autorité</h1>
+      <p>Renforcer la crédibilité de votre site grâce à des partenariats de qualité.</p>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="container">
+      <h2>Pourquoi les liens restent essentiels</h2>
+      <p>Les liens sont l’un des signaux majeurs utilisés par les moteurs pour évaluer la confiance accordée à un site. Bien exploités, ils renforcent la visibilité et la légitimité de votre marque.</p>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="container">
+      <h2>Typologie de liens &amp; sélection des domaines</h2>
+      <p>Analyser les typologies de liens permet de privilégier les sources pertinentes : médias, blogs spécialisés ou partenaires sectoriels. Chaque domaine est choisi en fonction de sa cohérence thématique et de son audience.</p>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="container">
+      <h2>Suivi de l’autorité &amp; veille concurrentielle</h2>
+      <p>Le suivi des indicateurs d’autorité et la surveillance des stratégies concurrentes garantissent une progression maîtrisée et mesurable.</p>
+    </div>
+  </section>
+
+  <section class="section">
+    <div class="container">
+      <h2>Gestion des risques (toxicité, désaveu)</h2>
+      <p>Un contrôle régulier des profils de liens permet d’identifier les signaux de toxicité et de désavouer les sources nuisibles avant qu’elles n’affectent votre référencement.</p>
+    </div>
+  </section>
+
+  <section class="cta">
+    <div class="container">
+      <h2>Besoin d’un plan de netlinking sur mesure&nbsp;?</h2>
+      <a href="/#contact" class="btn btn-light">Discutons-en</a>
+    </div>
+  </section>
+
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-top">
+        <div class="footer-logo">Marc Williame</div>
+        <ul class="footer-nav">
+          <li><a href="/#services">Services</a></li>
+          <li><a href="/#about">À propos</a></li>
+          <li><a href="/#contact">Contact</a></li>
+        </ul>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; 2025 Marc Williame. Tous droits réservés.</p>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add netlinking authority service page with common header and footer
- include SEO title and description
- outline link strategy, risk management and CTA

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4753a0e348329a0af820d4d060714