### PR TITLE
Add semantic content strategy service page

### DIFF
--- a/strategie-contenu-analyse-semantique/index.html
+++ b/strategie-contenu-analyse-semantique/index.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Stratégie de contenu &amp; analyse sémantique - Consultant SEO</title>
+  <meta name="description" content="Aligner votre contenu avec l'intention de recherche grâce à la cartographie sémantique, un planning éditorial data-driven et une optimisation continue." />
+  <link rel="stylesheet" href="../style.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Space+Grotesk:wght@700&display=swap" rel="stylesheet">
+  <script defer src="../script.js"></script>
+</head>
+<body>
+  <!-- Header / Navigation -->
+  <header class="header">
+    <div class="container">
+      <div class="logo">Consultant<strong>SEO</strong></div>
+      <nav class="nav">
+        <ul>
+          <li><a href="/#services">Services</a></li>
+          <li><a href="/#contact" class="btn">Contact</a></li>
+          <li><a href="/#about">À propos</a></li>
+          <li><a href="/#tools">Outils</a></li>
+          <li><a href="/#process">Méthodologie</a></li>
+          <li><a href="/#clients">Clients</a></li>
+          <li><a href="/#faq">FAQ</a></li>
+        </ul>
+        <button class="nav-toggle" aria-label="menu">&#9776;</button>
+      </nav>
+    </div>
+  </header>
+
+  <!-- Hero -->
+  <section class="hero">
+    <div class="container hero-content">
+      <div class="hero-text">
+        <h1>Stratégie de contenu &amp; analyse sémantique</h1>
+        <p class="hero-subtitle">Transformer les données en plan éditorial performant.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Align content and search intent -->
+  <section class="section">
+    <div class="container">
+      <h2 class="section-title">Aligner contenu et intention de recherche</h2>
+      <p>Chaque requête cache une attente précise. En analysant les intentions de recherche, le contenu est façonné pour y répondre avec exactitude et gagner en pertinence.</p>
+    </div>
+  </section>
+
+  <!-- Semantic mapping & clustering -->
+  <section class="section section--alt">
+    <div class="container">
+      <h2 class="section-title">Cartographie sémantique &amp; clustering</h2>
+      <p>Les données issues de la recherche permettent de construire des grappes thématiques cohérentes. Cette cartographie guide la structure du site et renforce sa légitimité sur chaque sujet.</p>
+    </div>
+  </section>
+
+  <!-- Data-driven editorial planning -->
+  <section class="section">
+    <div class="container">
+      <h2 class="section-title">Planning éditorial data-driven</h2>
+      <p>Les opportunités sont priorisées selon leur potentiel. Les sujets à fort impact sont planifiés pour alimenter un calendrier éditorial aligné sur vos objectifs business.</p>
+    </div>
+  </section>
+
+  <!-- Continuous optimization -->
+  <section class="section section--alt">
+    <div class="container">
+      <h2 class="section-title">Optimisation continue</h2>
+      <p>Les performances sont suivies régulièrement afin d'ajuster le contenu, enrichir les pages et capitaliser sur les signaux envoyés par les utilisateurs comme par les moteurs.</p>
+    </div>
+  </section>
+
+  <!-- CTA -->
+  <section class="cta">
+    <div class="container">
+      <h2>Besoin d'une stratégie de contenu performante&nbsp;?</h2>
+      <a href="/#contact" class="btn btn-light">Discutons-en</a>
+    </div>
+  </section>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="container">
+      <div class="footer-top">
+        <div class="footer-logo">Marc Williame</div>
+        <ul class="footer-nav">
+          <li><a href="/#services">Services</a></li>
+          <li><a href="/#about">À propos</a></li>
+          <li><a href="/#contact">Contact</a></li>
+        </ul>
+      </div>
+      <div class="footer-bottom">
+        <p>&copy; 2025 Marc Williame. Tous droits réservés.</p>
+      </div>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `strategie-contenu-analyse-semantique` service page with header and footer
- include sections on search intent alignment, semantic mapping, editorial planning, and continuous optimization
- link final call-to-action to `/#contact`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c47537d6ec8329b7dabc3a6400a062