### PR TITLE
Use SVG for hero banner background

### DIFF
--- a/images/hero.svg
+++ b/images/hero.svg
@@ -1,11 +1,11 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="450" height="350">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 600" preserveAspectRatio="xMidYMid slice">
   <defs>
-    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#b8a1e3;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#a9e5bb;stop-opacity:1" />
+    <linearGradient id="hero-gradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#4f46e5" />
+      <stop offset="100%" stop-color="#0ea5e9" />
     </linearGradient>
   </defs>
-  <rect width="450" height="350" fill="url(#grad)" />
-  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle"
-        font-family="Roboto, sans-serif" font-size="48" fill="#ffffff">SEO</text>
+  <rect width="1440" height="600" fill="url(#hero-gradient)" />
+  <circle cx="180" cy="120" r="80" fill="rgba(255,255,255,0.15)" />
+  <circle cx="1260" cy="480" r="120" fill="rgba(255,255,255,0.1)" />
 </svg>

--- a/style.css
+++ b/style.css
@@ -118,7 +118,7 @@ a {
 
 /* Hero */
 .hero {
-  background: url("images/cdc88f7f-71ed-480b-aec6-ccffb3f45c6d.png") center/cover no-repeat;
+  background: url("images/hero.svg") center/cover no-repeat;
   color: #fff;
   padding: 6rem 0;
   position: relative;


### PR DESCRIPTION
## Summary
- Add new `images/hero.svg` banner artwork with gradient background
- Reference `images/hero.svg` in `.hero` section instead of PNG file

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c47e2de97883299ba3c0389dea37f0