### PR TITLE
Add dark section variant and card highlight styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,37 +49,37 @@
       <p>En tant que consultant SEO freelance, j’ai choisi une approche orientée data et IA. Pas pour remplacer l’humain, mais pour libérer du temps, fiabiliser les analyses et transformer les données en décisions claires.</p>
       <p>Le référencement n’est pas seulement une question de mots-clés ou de backlinks : c’est un équilibre entre technique, contenu, autorité et expérience utilisateur. Mon rôle est de mettre de l’ordre dans cette complexité pour que vous puissiez vous concentrer sur ce qui compte : faire grandir votre projet.</p>
       <div class="cards">
-        <div class="card">
+        <div class="card card--highlight">
           <img src="images/generated/audit.svg" alt="Audit SEO avancé" />
           <h3>Audit SEO avancé</h3>
           <p>Un audit, ce n’est pas une liste d’erreurs dans un fichier Excel. C’est une radiographie complète du site : indexation, architecture, performance, signaux techniques. L’objectif n’est pas de pointer des défauts, mais de comprendre comment le site est perçu par Google et où se trouvent les leviers concrets de progression.</p>
           <a class="btn btn-light" href="./seo-audit.html">Découvrir</a>
         </div>
-        <div class="card">
+        <div class="card card--highlight">
           <img src="images/generated/optimisation.svg" alt="Optimisation technique et performance" />
           <h3>Optimisation technique &amp; performance</h3>
           <p>Un site rapide et bien structuré n’est pas seulement apprécié des moteurs de recherche : c’est aussi une meilleure expérience pour vos utilisateurs. Ici, l’approche consiste à aligner performance technique et SEO : vitesse, mobile, Core Web Vitals, structure HTML.</p>
           <a class="btn btn-light" href="./technical-seo.html">Découvrir</a>
         </div>
-        <div class="card">
+        <div class="card card--highlight">
           <img src="images/generated/contenu.svg" alt="Stratégie de contenu" />
           <h3>Stratégie de contenu &amp; analyse sémantique</h3>
           <p>Un contenu qui fonctionne n’est pas forcément le plus long, mais celui qui répond exactement à l’intention de recherche. Grâce à l’analyse sémantique et aux données issues de vos utilisateurs, il devient possible d’identifier les sujets à fort potentiel, de hiérarchiser vos pages et de construire une vraie architecture éditoriale.</p>
           <a class="btn btn-light" href="./content-strategy.html">Découvrir</a>
         </div>
-        <div class="card">
+        <div class="card card--highlight">
           <img src="images/generated/netlinking.svg" alt="Netlinking et autorité" />
           <h3>Netlinking &amp; autorité</h3>
           <p>Les liens restent un pilier du SEO. Mais il ne s’agit pas d’en accumuler sans logique. Une bonne stratégie de netlinking, c’est créer un écosystème de confiance autour de votre site, en ciblant les bons partenariats, les bons contenus, et en renforçant la crédibilité de votre marque.</p>
           <a class="btn btn-light" href="./link-building.html">Découvrir</a>
         </div>
-        <div class="card">
+        <div class="card card--highlight">
           <img src="images/generated/local.svg" alt="Référencement local" />
           <h3>Référencement local</h3>
           <p>Être visible dans sa zone géographique, c’est souvent plus rentable que de chercher une visibilité mondiale. Le SEO local permet de capter des prospects proches, de renforcer votre présence dans Google Maps et d’optimiser vos fiches locales.</p>
           <a class="btn btn-light" href="./local-seo.html">Découvrir</a>
         </div>
-        <div class="card">
+        <div class="card card--highlight">
           <img src="images/generated/automatisation-reporting.svg" alt="Automatisation et reporting SEO" />
           <h3>Automatisation &amp; reporting SEO</h3>
           <p>Le SEO génère une montagne de données. Sans automatisation, on finit vite noyé. Tableaux de bord, alertes, suivi d’indexation, rapports automatiques : l’idée est de vous donner une vision claire et en temps réel de vos performances.</p>
@@ -90,24 +90,24 @@
   </section>
 
   <!-- Services en mode sombre -->
-  <section id="services-plus" class="section services services--alt">
+  <section id="services-plus" class="section section--dark services services--alt">
     <div class="container">
       <h2 class="section-title">Services data &amp; IA</h2>
       <p>Le SEO moderne dépasse le simple champ du contenu. Aujourd’hui, les projets les plus performants intègrent des briques data et IA :</p>
       <div class="cards cards--alt">
-        <div class="card card--dark">
+        <div class="card card--highlight">
           <img src="images/generated/methodologie.svg" alt="Tableaux de bord" />
           <h3>Tableaux de bord</h3>
           <p>Visualisation de vos données SEO pour des décisions éclairées.</p>
           <a class="btn btn-light" href="/dashboards.html">Découvrir</a>
         </div>
-        <div class="card card--gradient">
+        <div class="card card--highlight">
           <img src="images/generated/automatisation-reporting.svg" alt="Automatisation IA" />
           <h3>Automatisation IA</h3>
           <p>Scripts et workflows pour accélérer vos analyses.</p>
           <a class="btn btn-light" href="/automatisation-ai.html">Découvrir</a>
         </div>
-        <div class="card card--dark">
+        <div class="card card--highlight">
           <img src="images/generated/audit.svg" alt="Stratégie data" />
           <h3>Stratégie data</h3>
           <p>Exploitation des données pour guider votre stratégie SEO.</p>
@@ -190,7 +190,7 @@
   </section>
 
   <!-- Methodology -->
-  <section id="process" class="section process">
+  <section id="process" class="section section--dark process">
     <div class="container">
       <h2 class="section-title">Méthodologie</h2>
       <div class="steps">
@@ -249,7 +249,7 @@
   </section>
 
   <!-- CTA -->
-  <section class="cta">
+  <section class="cta section--dark">
     <div class="container">
       <h2>Prêt à booster votre SEO&nbsp;?</h2>
       <a href="#contact" class="btn btn-light">Discutons-en</a>

--- a/style.css
+++ b/style.css
@@ -231,6 +231,14 @@ section:nth-of-type(even) {
   gap: 2rem;
 }
 
+.card--highlight {
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.1);
+  padding: 2rem;
+  color: var(--text);
+}
+
 .card--dark {
   background: #1f2937;
   color: #fff;
@@ -311,6 +319,28 @@ section:nth-of-type(even) {
 }
 .cta h2 {
   margin: 0 0 1rem;
+}
+
+/* Dark section theme */
+.section--dark {
+  background: #111827;
+  color: #fff;
+}
+
+.section--dark a {
+  color: #fff;
+}
+
+.section--dark .section-title {
+  color: #fff;
+}
+
+.section--dark .card--highlight {
+  color: var(--text);
+}
+
+.section--dark .btn-light {
+  color: var(--primary-dark);
 }
 
 /* Footer */


### PR DESCRIPTION
## Summary
- add reusable `.section--dark` styling and `.card--highlight` visual treatment
- apply dark theme to services-plus, process and call-to-action sections
- switch service cards to `.card--highlight` for better contrast

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c58133a040832992f5cabd40d7b001