### PR TITLE
Revamp hero section with gradient background and new CTA

### DIFF
--- a/images/stars.svg
+++ b/images/stars.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+  <circle cx="10" cy="15" r="1" fill="white"/>
+  <circle cx="40" cy="30" r="1" fill="white"/>
+  <circle cx="70" cy="20" r="1" fill="white"/>
+  <circle cx="90" cy="40" r="1" fill="white"/>
+  <circle cx="20" cy="70" r="1" fill="white"/>
+  <circle cx="50" cy="60" r="1" fill="white"/>
+  <circle cx="80" cy="80" r="1" fill="white"/>
+  <circle cx="30" cy="90" r="1" fill="white"/>
+</svg>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <title>Expert SEO freelance spécialisé en data et automatisation</title>
   <meta name="description" content="Consultant SEO indépendant, spécialisé dans l'analyse de données, l'automatisation et l'IA pour booster votre visibilité en ligne." />
   <link rel="stylesheet" href="style.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Space+Grotesk:wght@700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Space+Grotesk:wght@700&family=Sora:wght@700&display=swap" rel="stylesheet">
   <script defer src="script.js"></script>
 </head>
 <body>
@@ -36,7 +36,7 @@
       <div class="hero-text">
         <h1>Consultant SEO freelance orienté data &amp; IA</h1>
         <p class="hero-subtitle">Chaque site a son potentiel caché. L’analyse de données et l’automatisation permettent de le révéler et d’en faire un levier durable.</p>
-        <a href="#contact" class="btn btn-light">Parlons de votre projet</a>
+        <a href="#contact" class="btn hero-cta">Parlons de votre projet</a>
       </div>
     </div>
   </section>

--- a/style.css
+++ b/style.css
@@ -118,7 +118,7 @@ a {
 
 /* Hero */
 .hero {
-  background: url("images/ChatGPT Image 13 sep 2025, 15_17_39.png") center/cover no-repeat;
+  background: linear-gradient(180deg, #0F172A 0%, #1E293B 100%);
   color: #fff;
   padding: 6rem 0;
   position: relative;
@@ -129,7 +129,9 @@ a {
   content: "";
   position: absolute;
   inset: 0;
-  background: rgba(0, 0, 0, 0.4);
+  background: url("images/stars.svg") repeat;
+  opacity: 0.2;
+  pointer-events: none;
 }
 
 .hero-content {
@@ -143,7 +145,9 @@ a {
   max-width: 600px;
 }
 .hero-text h1 {
-  font-size: 2.5rem;
+  font-family: 'Sora', sans-serif;
+  font-size: 4rem;
+  letter-spacing: 0.5px;
   line-height: 1.2;
   margin-top: 0;
   margin-bottom: 0.5rem;
@@ -157,6 +161,15 @@ a {
   right: 5%;
   bottom: 0;
   width: 300px;
+}
+
+.hero-cta {
+  background: linear-gradient(90deg, var(--primary) 0%, var(--secondary) 100%);
+  color: #fff;
+}
+
+.hero-cta:hover {
+  background: linear-gradient(90deg, var(--primary-dark) 0%, var(--secondary) 100%);
 }
 
 /* Sections */
@@ -363,6 +376,12 @@ section:nth-of-type(even) {
 
 /* Responsive */
 @media (max-width: 768px) {
+  .hero {
+    padding: 4rem 0;
+  }
+  .hero-text h1 {
+    font-size: 2.5rem;
+  }
   .footer-nav {
     flex-direction: column;
     gap: 0.75rem;


### PR DESCRIPTION
## Summary
- Replace hero background image with a dark gradient and add a star texture overlay
- Switch hero heading to Sora font with larger sizing and spacing
- Introduce `.hero-cta` gradient button and apply to hero section link

## Testing
- `npm test` *(fails: Could not read package.json)*
- `python contrast_check.py` *(manual contrast ratios: #4F46E5 vs white = 6.29, #9333EA vs white = 5.38)*

------
https://chatgpt.com/codex/tasks/task_e_68c5812bd75083298851315b0b3e80ac