### PR TITLE
feat: update palette to accessible orange scheme

### DIFF
--- a/style-guide.md
+++ b/style-guide.md
@@ -1,0 +1,14 @@
+# Fiche de style
+
+## Couleurs
+
+### Principales
+- **Primary** `#FF6A00`
+- **Primary Dark** `#C65300`
+- **Secondary** `#FF8A3D`
+
+### Secondaires / neutres
+- **Gris foncé** `#222222`
+- **Beige clair** `#F5F1EB`
+
+Ces teintes sont appliquées via les classes existantes (par ex. `.section--dark` et les sections alternées) pour assurer une cohérence visuelle et un contraste accessible.

--- a/style.css
+++ b/style.css
@@ -1,11 +1,13 @@
 /* Base */
 :root {
-  --primary: #4F46E5;     /* bleu-violet */
-  --primary-dark: #3730A3;/* bleu-violet foncé */
-  --secondary: #9333EA;   /* accent violet */
+  --primary: #FF6A00;     /* orange vif */
+  --primary-dark: #C65300;/* orange foncé */
+  --secondary: #FF8A3D;   /* accent orange */
+  --dark: #222222;        /* gris foncé */
+  --beige: #F5F1EB;       /* beige clair */
   --light: #F5F7FA;       /* fond clair */
   --text: #1A1A1A;
-  --section-alt: #E5E7EB;
+  --section-alt: var(--beige);
   --gray: #777;
   --radius: 6px;
 }
@@ -59,7 +61,7 @@ a {
 .btn {
   display: inline-block;
   background: linear-gradient(135deg, var(--primary), var(--secondary));
-  color: #fff;
+  color: var(--text);
   padding: 0.7rem 1.5rem;
   border-radius: 9999px;
   transition: background .3s, transform .2s ease, box-shadow .2s ease;
@@ -68,6 +70,7 @@ a {
   background: var(--primary-dark);
   transform: translateY(-4px);
   box-shadow: 0 0 10px var(--primary);
+  color: #fff;
 }
 .card {
   transition: transform .2s ease, box-shadow .2s ease;
@@ -93,7 +96,7 @@ a {
 .logo {
   font-size: 1.4rem;
   font-weight: 700;
-  color: var(--primary);
+  color: var(--primary-dark);
 }
 .nav {
   display: flex;
@@ -168,11 +171,12 @@ a {
 
 .hero-cta {
   background: linear-gradient(90deg, var(--primary) 0%, var(--secondary) 100%);
-  color: #fff;
+  color: var(--text);
 }
 
 .hero-cta:hover {
   background: linear-gradient(90deg, var(--primary-dark) 0%, var(--secondary) 100%);
+  color: #fff;
 }
 
 /* Sections */
@@ -181,6 +185,7 @@ a {
   margin: 0;
 }
 
+.section--alt,
 section:nth-of-type(even) {
   background: var(--section-alt);
 }
@@ -302,7 +307,7 @@ section:nth-of-type(even) {
   margin: 0 auto 1rem;
   border-radius: 50%;
   background: var(--secondary);
-  color: #fff;
+  color: var(--text);
   font-size: 1.4rem;
   font-weight: 700;
 }
@@ -339,7 +344,7 @@ section:nth-of-type(even) {
 
 /* Dark section theme */
 .section--dark {
-  background: #111827;
+  background: var(--dark);
   color: #fff;
 }
 
@@ -361,7 +366,7 @@ section:nth-of-type(even) {
 
 /* Footer */
 .footer {
-  background: #111827;
+  background: var(--dark);
   color: #fff;
   padding: 2rem 0;
 }


### PR DESCRIPTION
## Summary
- restyle site with orange-themed primary, secondary, and dark variables
- ensure buttons, hero CTA, and numbered steps use accessible text contrast
- document secondary and neutral colors in a style guide

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c59545ab088329b1d8e5e3c3905ab2