### PR TITLE
style: align gradients with brand palette

### DIFF
--- a/style.css
+++ b/style.css
@@ -131,7 +131,7 @@ a {
 
 /* Hero */
 .hero {
-  background: linear-gradient(180deg, #0F172A 0%, #1E293B 100%);
+  background: linear-gradient(180deg, var(--primary-dark) 0%, var(--primary) 100%);
   color: #fff;
   padding: 6rem 0;
   position: relative;
@@ -241,10 +241,10 @@ section:nth-of-type(even) {
   content: "";
   position: absolute;
   inset: 0;
-  background: rgba(79, 70, 229, 0.1);
+  background: rgba(255, 106, 0, 0.1);
   background-image: url("images/stars.svg");
   background-size: cover;
-  mix-blend-mode: multiply;
+  mix-blend-mode: screen;
   pointer-events: none;
 }
 
@@ -301,17 +301,17 @@ section:nth-of-type(even) {
 }
 
 .card--gradient {
-  background: linear-gradient(135deg, #1e3a8a, #3b82f6);
+  background: linear-gradient(135deg, var(--primary-dark), var(--secondary));
   color: #fff;
 }
 .card--gradient:hover {
-  background: linear-gradient(135deg, #1e40af, #2563eb);
+  background: linear-gradient(135deg, var(--primary), var(--secondary));
   box-shadow: 0 8px 16px rgba(0,0,0,0.3);
 }
 
 /* Methodology */
 .process {
-  background: #1E3A8A;
+  background: linear-gradient(135deg, var(--primary-dark), var(--primary));
   color: #fff;
   margin-top: 2rem;
 }
@@ -364,10 +364,13 @@ section:nth-of-type(even) {
 
 /* CTA */
 .cta {
-  background: linear-gradient(135deg, #1f2937, #0f172a);
+  background: linear-gradient(135deg, var(--primary-dark), var(--primary));
   color: #fff;
   text-align: center;
   padding: 3rem 0;
+}
+.cta:hover {
+  background: var(--primary-dark);
 }
 .cta h2 {
   margin: 0 0 1rem;
@@ -493,7 +496,7 @@ section:nth-of-type(even) {
 }
 
 #contact {
-  background: linear-gradient(135deg, #8B5CF6, #EC4899);
+  background: linear-gradient(135deg, var(--primary), var(--secondary));
   color: #fff;
 }
 


### PR DESCRIPTION
## Summary
- update hero, card, CTA, methodology, and contact gradients to use primary/secondary variables
- adjust overlay card colors and blend mode
- add CTA hover background

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5997f532c83298b1347a93ef7e41b